### PR TITLE
Macro invocation identification

### DIFF
--- a/tree-sitter-topas/queries/highlights.scm
+++ b/tree-sitter-topas/queries/highlights.scm
@@ -3,3 +3,9 @@
 (string_literal) @string
 (integer_literal) @number
 (float_literal) @number
+
+(macro_invocation name: (identifier) @function.macro)
+(argument_list ( _ (identifier) @variable.parameter))
+
+"@" @operator
+"!" @operator

--- a/tree-sitter-topas/test/corpus/macros.inp
+++ b/tree-sitter-topas/test/corpus/macros.inp
@@ -1,0 +1,43 @@
+=================
+Macro Invocations
+=================
+
+Cubic(cv)
+Cubic(cv,cv2)
+Testmacro2
+PO(arg1,,arg3)
+
+Failmacro (arg)
+Failmacro2(%)
+-----------------
+
+(source_file
+    (macro_invocation
+        (identifier)
+        (argument_list
+          (identifier)))
+    (macro_invocation
+        (identifier)
+        (argument_list
+          (identifier)
+          (identifier)))
+    (macro_invocation
+        (identifier))
+    (macro_invocation
+        (identifier)
+        (argument_list
+          (identifier)
+          (identifier)))
+
+    (macro_invocation
+        (identifier))
+      (ERROR)
+    (macro_invocation
+      (identifier))
+    (ERROR)
+    (macro_invocation
+      (identifier)
+      (argument_list
+        (ERROR
+          (UNEXPECTED '%')))))
+


### PR DESCRIPTION
I've written grammar rules and a test file for macro invocations, including for identifiers and parameters. 
I've also included the abilities to pass parameters for refinement with `@` or to tag them as not to be refined with `!`, though I wonder if there's a more concise way of dealing with the parameters - do you think it's worth creating a `$._parameter` to contain literal, identifier and (un)refined_parameter, given I'll likely be needing those same options again?

Also, should I be adding deliberate failures to the test file?