### PR TITLE
Add macro declaration grammar, tests and highlights

### DIFF
--- a/tree-sitter-topas/grammar.js
+++ b/tree-sitter-topas/grammar.js
@@ -131,7 +131,28 @@ module.exports = grammar({
       $.unrefined_parameter,
     ),
 
+    parameter_list: $ => seq(
+      token.immediate('('),
+      optional('&'),
+      optional($.identifier),
+      repeat(seq(',', optional('&'), optional($.identifier))),
+      ')',
+    ),
+
+    macro_declaration: $ => seq(
+      token('macro'),
+      optional('&'),
+      field('name', $.identifier),
+      field('parameters', optional($.parameter_list)),
+      field('body', seq(
+        '{',
+        repeat($._block_item),
+        '}',
+      )),
+    ),
+
     _global_preprocessor_directive: $ => choice(
+      $.macro_declaration,
       $.preprocessor_include,
       $.preprocessor_delete,
       $.preprocessor_define,
@@ -425,7 +446,6 @@ module.exports = grammar({
       'lp_search',
       'm1',
       'm2',
-      'macro',
       'mag_atom_out',
       'mag_only',
       'mag_only_for_mag_sites',

--- a/tree-sitter-topas/queries/highlights.scm
+++ b/tree-sitter-topas/queries/highlights.scm
@@ -9,7 +9,11 @@
 [
     "@"
     "!" 
+    "&"
 ] @operator
+
+"macro" @keyword.preprocessor
+(macro_declaration name: (identifier) @function.macro)
 
 ( _ directive: _ @keyword.preprocessor)
 

--- a/tree-sitter-topas/test/corpus/macro_definition.inp
+++ b/tree-sitter-topas/test/corpus/macro_definition.inp
@@ -1,0 +1,28 @@
+==================
+Macro Declarations
+==================
+
+macro My_macro(& var1, var2){
+    a = 5 * 2; : 0 
+    activate PI
+} 
+macro name {}
+
+------------------
+
+(source_file
+    (macro_declaration
+        (identifier)
+        (parameter_list
+            (identifier)
+            (identifier))
+        (equation
+            (definition)
+            (binary_expression
+                (integer_literal)
+                (integer_literal))
+        (integer_literal))
+        (definition)
+        (identifier))
+    (macro_declaration
+        (identifier)))


### PR DESCRIPTION
Implement the `macro` preprocessor directive, which is used to create new macros. A macro declaration uses the format:
`macro Macro_name( parameters ) { body }`
with the following notes:
- The parameters field (including the parentheses) is entirely optional.
- An ampersand `&` can optionally precede the `Macro_name` and/or any of the `parameters`. This signals to the TOPAS preprocessor that the macro/parameters should be inlined into the code within parentheses.
- The body can contain code that would otherwise be syntactically invalid, such as expressions outside the equation format.