### PR TITLE
Macro preprocessor directives

### DIFF
--- a/tree-sitter-topas/grammar.js
+++ b/tree-sitter-topas/grammar.js
@@ -146,7 +146,7 @@ module.exports = grammar({
       field('parameters', optional($.parameter_list)),
       field('body', seq(
         '{',
-        repeat($._block_item),
+        repeat(choice($._block_item, $._macro_preprocessor_directive)),
         '}',
       )),
     ),
@@ -209,6 +209,58 @@ module.exports = grammar({
       field('directive', '#else'),
       optional(repeat($._block_item)),
     ),
+
+    _macro_preprocessor_directive: $ => choice(
+      $.macro_if_statement,
+      $.macro_operator_directive,
+      alias($._macro_unique, $.macro_operator_directive),
+    ),
+
+    macro_if_statement: $ => seq(
+      choice(
+        $._m_if,
+        $._m_ifarg,
+      ),
+      repeat($._m_elseif),
+      optional($._m_else),
+      field('directive', '#m_endif'),
+    ),
+
+    _m_if: $ => seq(
+      field('directive', '#m_if'),
+      field('argument', $.binary_expression),
+      ';',
+      optional(repeat($._block_item)),
+    ),
+
+    _m_elseif: $ => seq(
+      field('directive', '#m_elseif'),
+      field('argument', $.binary_expression),
+      ';',
+      optional(repeat($._block_item)),
+    ),
+
+    _m_ifarg: $ => seq(
+      field('directive', '#m_ifarg'),
+      field('argument', $.identifier),
+      choice(
+        field('directive', choice('#m_code', '#_eqn', '#m_code_refine', '#m_one_word')),
+        $.string_literal,
+      ),
+      optional(repeat($._block_item)),
+    ),
+
+    _m_else: $ => seq(
+      field('directive', '#m_else'),
+      optional(repeat($._block_item)),
+    ),
+
+    macro_operator_directive: $ => choice(
+      field('directive', choice('#m_argu', '#m_first_word', '#m_unique_not_refine')),
+      field('argument', $.identifier),
+    ),
+
+    _macro_unique: $ => field('directive', '#m_unique'),
 
     definition: $ => choice(
       'a',

--- a/tree-sitter-topas/test/corpus/preprocessor.inp
+++ b/tree-sitter-topas/test/corpus/preprocessor.inp
@@ -39,3 +39,93 @@ Include file
 (source_file
     (preprocessor_include
         (string_literal)))
+
+============================
+Macro directive if statement
+============================
+
+macro TEST(arg1) {
+    #m_if arg1 == 2;
+        al arg1
+    #m_elseif arg1 == 1;
+        be arg1
+    #m_else
+        ga arg1
+    #m_endif
+}
+
+----------------------------
+
+(source_file
+    (macro_declaration
+        (identifier)
+        (parameter_list
+          (identifier))
+          (macro_if_statement
+            (binary_expression
+              (identifier)
+              (integer_literal))
+            (definition)
+            (identifier)
+            (binary_expression
+              (identifier)
+              (integer_literal))
+            (definition)
+            (identifier)
+            (definition)
+            (identifier))))
+
+======================
+Macro directive if_arg
+======================
+
+macro TEST(arg1) {
+    #m_ifarg arg1 "some string"
+        parameter = 5;
+    #m_endif
+
+    #m_ifarg arg1 #m_code
+        parameter = 1;
+    #m_endif
+}
+
+----------------------
+(source_file
+    (macro_declaration
+        (identifier)
+        (parameter_list
+          (identifier))
+        (macro_if_statement
+          (identifier)
+          (string_literal)
+          (equation
+            (identifier)
+            (integer_literal)))
+        (macro_if_statement
+          (identifier)
+          (equation
+            (identifier)
+            (integer_literal)))))
+
+========================
+Macro directive operator
+========================
+
+macro Operate(arg) {
+    #m_first_word arg
+    #m_unique_not_refine arg
+    #m_argu arg
+}
+
+------------------------
+(source_file
+      (macro_declaration
+        (identifier)
+        (parameter_list
+          (identifier))
+        (macro_operator_directive)
+        (identifier)
+        (macro_operator_directive)
+        (identifier)
+        (macro_operator_directive)
+        (identifier)))


### PR DESCRIPTION
Implement identification and testing for macro preprocessor directives i.e., directives that can only be included within the body of a macro and are invoked when the macro is expanded. The complete list of macro invocation directives is:
```
#m_if, #m_ifarg, #m_elseif, #m_else, #m_endif
#m_code, #m_eqn, #m_code_refine, #m_one_word
#m_argu, #m_first_word, #m_unique_not_refine, 
#m_unique
```
The directives on the first line allow for `if` statements to be constructed within macro bodies, while the others behave more like functions or operators - for details of their usage, see the TOPAS Technical Reference, Section 19.1.3

These directives are compatible with the queries introduced for global directives, so no new queries are added for highlighting.