### PR TITLE
Restructure and expand test corpus

### DIFF
--- a/tree-sitter-topas/test/corpus/comments.inp
+++ b/tree-sitter-topas/test/corpus/comments.inp
@@ -1,21 +1,31 @@
-========
-Comments
-========
+=============
+Line comments
+=============
 
 'test comment
 activate
 'activate
-/* multi-line
-comment */
-activate
---------
 
+-------------
 (source_file
   (comment
     (line_comment))
   (definition)
   (comment
-    (line_comment))
+    (line_comment)))
+
+==============
+Block comments
+==============
+
+/* multi-line
+correct_for_atomic_scattering_factors
+'line comment within a block comment
+comment */
+activate
+
+--------------
+(source_file
   (comment
     (block_comment))
   (definition))

--- a/tree-sitter-topas/test/corpus/expressions.inp
+++ b/tree-sitter-topas/test/corpus/expressions.inp
@@ -1,93 +1,192 @@
-===========
-Expressions
-===========
+==================
+Simple expressions
+==================
 
 x = 5;
 new_var = 1 /old_var;
+subtraction = x - 5;
+addition = 5 + x;
+exponentiation = 15.2 ^ x;
+
+------------------
+(source_file
+  (equation
+    (definition)
+    (integer_literal))
+  (equation
+    (identifier)
+    (binary_expression
+      (integer_literal)
+      (identifier)))
+  (equation
+    (identifier)
+    (binary_expression
+      (identifier)
+      (integer_literal)))
+  (equation
+    (identifier)
+    (binary_expression
+      (integer_literal)
+      (identifier)))
+  (equation
+    (identifier)
+    (binary_expression
+      (float_literal)
+      (identifier))))
+
+==========================
+Binary operator precedence
+==========================
+
 new_var *= old_var+1 / 2;
 new_var *= (old_var+1) * 2;
+
+--------------------------
+(source_file
+  (equation
+    (identifier)
+    (binary_expression
+      (identifier)
+      (binary_expression
+        (integer_literal)
+        (integer_literal))))
+  (equation
+    (identifier)
+    (binary_expression
+      (parenthesised_expression
+        (binary_expression
+          (identifier)
+          (integer_literal)))
+      (integer_literal))))
+
+=========================
+Unary operator precedence
+=========================
 maths = - a1 * b2;
 exponent = -a2 ^ 3;
+multiply = a4 * - b5;
+negative_parentheses = - (a_variable);
+unary_subtraction = - 5 - 5;
+unary_exponent = x ^ +y;
+
+-------------------------
+(source_file
+  (equation
+      (identifier)
+      (binary_expression
+        (unary_expression
+          (identifier))
+        (identifier)))
+    (equation
+      (identifier)
+      (unary_expression
+        (binary_expression
+          (identifier)
+          (integer_literal))))
+    (equation
+      (identifier)
+      (binary_expression
+        (identifier)
+        (unary_expression
+          (identifier))))
+    (equation
+      (identifier)
+      (unary_expression
+        (parenthesised_expression
+          (identifier))))
+    (equation
+      (identifier)
+      (binary_expression
+        (unary_expression
+          (integer_literal))
+        (integer_literal)))
+    (equation
+      (identifier)
+      (binary_expression
+        (identifier)
+        (unary_expression
+          (identifier)))))
+
+=======================
+Implicit multiplication
+=======================
+
 implicit = var1 var2;
 implicit = var1 var2 ^ 3.2;
 ident_test = var1 (var2);
 macro_test = var1(var2);
+parentheses = (12.5/2) (var1 + 8);
+as_second_term = first_param / second_param 13.37;
+
+-----------------------
+(source_file
+  (equation
+    (identifier)
+    (binary_expression
+      (identifier)
+      (identifier)))
+  (equation
+    (identifier)
+    (binary_expression
+      (identifier)
+      (binary_expression
+        (identifier)
+        (float_literal))))
+  (equation
+    (identifier)
+    (binary_expression
+      (identifier)
+      (parenthesised_expression
+        (identifier))))
+  (equation
+    (identifier)
+    (macro_invocation
+      (identifier)
+      (argument_list
+        (identifier))))
+  (equation
+    (identifier)
+    (binary_expression
+      (parenthesised_expression
+        (binary_expression
+          (float_literal)
+          (integer_literal)))
+      (parenthesised_expression
+        (binary_expression
+          (identifier)
+          (integer_literal)))))
+  (equation
+    (identifier)
+    (binary_expression
+      (binary_expression
+        (identifier)
+        (identifier))
+      (float_literal))))
+
+==============================
+Expression as a macro argument
+==============================
+
 eqn_params = Divide(a/b);
 
-fail_test = 1 * 2
------------
+------------------------------
 
 (source_file
-      (equation
-        (definition)
-        (integer_literal))
-      (equation
-        (identifier)
-        (binary_expression
-          (integer_literal)
-          (identifier)))
-      (equation
-        (identifier)
+  (equation
+    (identifier)
+    (macro_invocation
+      (identifier)
+      (argument_list
         (binary_expression
           (identifier)
-          (binary_expression
-            (integer_literal)
-            (integer_literal))))
-      (equation
-        (identifier)
-        (binary_expression
-          (parenthesised_expression
-            (binary_expression
-              (identifier)
-              (integer_literal)))
-          (integer_literal)))
-      (equation
-        (identifier)
-        (binary_expression
-          (unary_expression
-            (identifier))
-          (identifier)))
-      (equation
-        (identifier)
-        (unary_expression
-          (binary_expression
-            (identifier)
-            (integer_literal))))
-      (equation
-        (identifier)
-        (binary_expression
-          (identifier)
-          (identifier)))
-      (equation
-        (identifier)
-        (binary_expression
-          (identifier)
-          (binary_expression
-            (identifier)
-            (float_literal))))
-      (equation
-        (identifier)
-        (binary_expression
-          (identifier)
-          (parenthesised_expression
-            (identifier))))
-      (equation
-        (identifier)
-        (macro_invocation
-          (identifier)
-          (argument_list
-            (identifier))))
-      (equation
-        (identifier)
-      (macro_invocation
-          (identifier)
-          (argument_list
-            (binary_expression
-              (identifier)
-              (identifier)))))
-      (equation
-        (identifier)
-        (binary_expression
-          (integer_literal)
-          (integer_literal))
-        (MISSING ";")))
+          (identifier))))))
+
+
+=================
+Missing semicolon
+:error
+=================
+
+fail_test = 1 * 2
+
+-----------------

--- a/tree-sitter-topas/test/corpus/macros.inp
+++ b/tree-sitter-topas/test/corpus/macros.inp
@@ -1,43 +1,75 @@
-=================
-Macro Invocations
-=================
+============
+No arguments
+============
+
+Testmacro2
+
+------------
+(source_file
+  (macro_invocation
+    (identifier)))
+
+===============
+Single argument
+===============
 
 Cubic(cv)
+Maths(12.4)
+
+---------------
+(source_file
+  (macro_invocation
+    (identifier)
+    (argument_list
+      (identifier)))
+  (macro_invocation
+    (identifier)
+    (argument_list
+      (float_literal))))
+
+==================
+Multiple arguments
+==================
+
 Cubic(cv,cv2)
-Testmacro2
+
+------------------
+(source_file
+  (macro_invocation
+    (identifier)
+    (argument_list
+      (identifier)
+      (identifier))))
+
+==============
+Empty argument
+==============
+
 PO(arg1,,arg3)
 
+--------------
+(source_file
+  (macro_invocation
+    (identifier)
+    (argument_list
+      (identifier)
+      (identifier))))
+
+====================
+Erroneous whitespace
+:error
+====================
+
 Failmacro (arg)
-Failmacro2($)
+
 -----------------
 
-(source_file
-    (macro_invocation
-        (identifier)
-        (argument_list
-          (identifier)))
-    (macro_invocation
-        (identifier)
-        (argument_list
-          (identifier)
-          (identifier)))
-    (macro_invocation
-        (identifier))
-    (macro_invocation
-        (identifier)
-        (argument_list
-          (identifier)
-          (identifier)))
+================
+Invalid argument
+:error
+================
 
-    (macro_invocation
-        (identifier))
-      (ERROR)
-    (macro_invocation
-      (identifier))
-    (ERROR)
-    (macro_invocation
-      (identifier)
-      (argument_list
-        (ERROR
-          (UNEXPECTED '$')))))
+Failmacro2($)
+
+----------------
 

--- a/tree-sitter-topas/test/corpus/numbers.inp
+++ b/tree-sitter-topas/test/corpus/numbers.inp
@@ -1,24 +1,45 @@
-=======
-Numbers
-=======
+========
+Integers
+========
 
 5
-"String 123"
-'12
-12.345
-1e10
-3.14e2
--5.2
+050
 
--------
-
+--------
 (source_file
   (integer_literal)
-  (string_literal)
-  (comment
-    (line_comment))
-  (float_literal)
-  (float_literal)
+  (integer_literal))
+
+=============
+Simple floats
+=============
+
+12.345
+-5.2
+
+-------------
+(source_file
   (float_literal)
   (float_literal))
 
+=================
+Scientific floats
+=================
+
+1e10
+3.14e2
+
+-----------------
+(source_file
+  (float_literal)
+  (float_literal))
+
+===================
+Number in a comment
+===================
+'12
+
+-------------------
+(source_file
+  (comment
+    (line_comment)))

--- a/tree-sitter-topas/test/corpus/strings.inp
+++ b/tree-sitter-topas/test/corpus/strings.inp
@@ -2,8 +2,8 @@
 Strings
 =======
 
-"This is_a string 123"
-"activate"
+"string"
+"%!=+"
 
 -------
 
@@ -11,3 +11,23 @@ Strings
       (string_literal)
       (string_literal))
 
+=======================================
+Strings containing numbers and keywords
+=======================================
+
+"string 123"
+"activate"
+
+---------------------------------------
+(source_file
+      (string_literal)
+      (string_literal))
+
+======================
+Missing closing quotes
+:error
+======================
+
+"open string
+
+----------------------


### PR DESCRIPTION
Reorganise and expand tests, using multiple test headers per file and the `:error` tag for expected failures.