### PR TITLE
Move comment rules to extras

### DIFF
--- a/tree-sitter-topas/grammar.js
+++ b/tree-sitter-topas/grammar.js
@@ -12,10 +12,14 @@ const PRECEDENCE = {
 module.exports = grammar({
   name: 'topas',
 
-  rules: {
-    source_file: $ => repeat(choice($.comment, $.macro_invocation, $.equation, $.definition, $._literal, $._global_preprocessor_directive)),
+  extras: $ => [
+    /\s|\n/,
+    $.line_comment,
+    $.block_comment,
+  ],
 
-    comment: $ => choice($.line_comment, $.block_comment),
+  rules: {
+    source_file: $ => repeat(choice($.macro_invocation, $.equation, $.definition, $._literal, $._global_preprocessor_directive)),
 
     line_comment: $ => /'.*/,
 
@@ -152,7 +156,6 @@ module.exports = grammar({
     _block_item: $ => choice(
       $.definition,
       $.equation,
-      $.comment,
       $._global_preprocessor_directive,
       $._expression,
       $.refined_parameter,

--- a/tree-sitter-topas/queries/highlights.scm
+++ b/tree-sitter-topas/queries/highlights.scm
@@ -1,5 +1,6 @@
 (definition) @keyword
-(comment) @comment
+(line_comment) @comment
+(block_comment) @comment
 (string_literal) @string
 (integer_literal) @number
 (float_literal) @number

--- a/tree-sitter-topas/test/corpus/comments.inp
+++ b/tree-sitter-topas/test/corpus/comments.inp
@@ -8,11 +8,9 @@ activate
 
 -------------
 (source_file
-  (comment
-    (line_comment))
+  (line_comment)
   (definition)
-  (comment
-    (line_comment)))
+  (line_comment))
 
 ==============
 Block comments
@@ -26,7 +24,7 @@ activate
 
 --------------
 (source_file
-  (comment
-    (block_comment))
+  (block_comment
+    (line_comment))
   (definition))
 

--- a/tree-sitter-topas/test/corpus/numbers.inp
+++ b/tree-sitter-topas/test/corpus/numbers.inp
@@ -41,5 +41,4 @@ Number in a comment
 
 -------------------
 (source_file
-  (comment
-    (line_comment)))
+    (line_comment))


### PR DESCRIPTION
Moves `line_comment` and `block_comment` to the `extras` field so that they no longer need to be specified as valid rules everywhere else in the grammar.

Due to a known issue with this version of Tree-sitter (https://github.com/tree-sitter/tree-sitter/issues/768#issuecomment-1953486321) using a `choice` in `extras` seems to cause generation to fail. Therefore, the `comment` rule is removed from this grammar and the  test/highlights are adjusted to match.