### PR TITLE
Restructuring equations

### DIFF
--- a/tree-sitter-topas/test/corpus/expressions.inp
+++ b/tree-sitter-topas/test/corpus/expressions.inp
@@ -2,7 +2,7 @@
 Simple expressions
 ==================
 
-x = 5;
+x1 = 5;
 new_var = 1 /old_var;
 subtraction = x - 5;
 addition = 5 + x;
@@ -10,26 +10,26 @@ exponentiation = 15.2 ^ x;
 
 ------------------
 (source_file
-  (equation
-    (definition)
+  (identifier)
+  (simple_assignment
     (integer_literal))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (integer_literal)
       (identifier)))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (identifier)
       (integer_literal)))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (integer_literal)
       (identifier)))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (float_literal)
       (identifier))))
@@ -43,15 +43,15 @@ new_var *= (old_var+1) * 2;
 
 --------------------------
 (source_file
-  (equation
-    (identifier)
+  (identifier)
+  (compound_assignment
     (binary_expression
       (identifier)
       (binary_expression
         (integer_literal)
         (integer_literal))))
-  (equation
-    (identifier)
+  (identifier)
+  (compound_assignment
     (binary_expression
       (parenthesised_expression
         (binary_expression
@@ -71,37 +71,37 @@ unary_exponent = x ^ +y;
 
 -------------------------
 (source_file
-  (equation
-      (identifier)
+  (identifier)
+    (simple_assignment
       (binary_expression
         (unary_expression
           (identifier))
         (identifier)))
-    (equation
-      (identifier)
+    (identifier)
+    (simple_assignment
       (unary_expression
         (binary_expression
           (identifier)
           (integer_literal))))
-    (equation
-      (identifier)
+    (identifier)
+    (simple_assignment
       (binary_expression
         (identifier)
         (unary_expression
           (identifier))))
-    (equation
-      (identifier)
+    (identifier)
+    (simple_assignment
       (unary_expression
         (parenthesised_expression
           (identifier))))
-    (equation
-      (identifier)
+    (identifier)
+    (simple_assignment
       (binary_expression
         (unary_expression
           (integer_literal))
         (integer_literal)))
-    (equation
-      (identifier)
+    (identifier)
+    (simple_assignment
       (binary_expression
         (identifier)
         (unary_expression
@@ -120,32 +120,32 @@ as_second_term = first_param / second_param 13.37;
 
 -----------------------
 (source_file
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (identifier)
       (identifier)))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (identifier)
       (binary_expression
         (identifier)
         (float_literal))))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (identifier)
       (parenthesised_expression
         (identifier))))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (macro_invocation
       (identifier)
       (argument_list
         (identifier))))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (parenthesised_expression
         (binary_expression
@@ -155,8 +155,8 @@ as_second_term = first_param / second_param 13.37;
         (binary_expression
           (identifier)
           (integer_literal)))))
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (binary_expression
       (binary_expression
         (identifier)
@@ -172,8 +172,8 @@ eqn_params = Divide(a/b);
 ------------------------------
 
 (source_file
-  (equation
-    (identifier)
+  (identifier)
+  (simple_assignment
     (macro_invocation
       (identifier)
       (argument_list

--- a/tree-sitter-topas/test/corpus/macro_definition.inp
+++ b/tree-sitter-topas/test/corpus/macro_definition.inp
@@ -16,8 +16,8 @@ macro name {}
         (parameter_list
             (identifier)
             (identifier))
-        (equation
-            (definition)
+        (definition)
+        (simple_assignment
             (binary_expression
                 (integer_literal)
                 (integer_literal))

--- a/tree-sitter-topas/test/corpus/preprocessor.inp
+++ b/tree-sitter-topas/test/corpus/preprocessor.inp
@@ -114,13 +114,13 @@ macro TEST(arg1) {
         (macro_if_statement
           (identifier)
           (string_literal)
-          (equation
-            (identifier)
+          (identifier)
+          (simple_assignment
             (integer_literal)))
         (macro_if_statement
           (identifier)
-          (equation
-            (identifier)
+          (identifier)
+          (simple_assignment
             (integer_literal)))))
 
 ========================


### PR DESCRIPTION
In order to implement variable declarations, the equation structure needs amending:
- The two equation types are split into separate rules. This is useful as the newly-named `reassignment_equation` is only valid when used with the `exisiting_prm` keyword, while an `initialisation_equation` can be used with many more keywords.
- The identifier/definition is moved outside the equation rule. While this removes the ability to have the left and right hand sides of the equation as child nodes of the equation, it allows equations to behave more like they do in TOPAS i.e., as an alternative to a literal when passing a value to a keyword.

To hopefully simplify future keyword implementations, `_refineable_value_expression` and `_fixed_value_expression` are introduced as rules to match the `E` and `!E` conventions of the TOPAS technical document respectively:
- E after keyword: An equation (i.e. `= a+b;`) or constant (i.e. `1.245`) or a parameter name with a
value (i.e. `lp 5.4013`) that can be refined.
- !E after keyword: An equation or constant or a parameter name with a value that cannot be
refined.

A function `refineable()` is defined to optionally add the `@` or `!` in front of any rule passed in as an argument. 



