### PR TITLE
Variable declarations

### DIFF
--- a/tree-sitter-topas/test/corpus/expressions.inp
+++ b/tree-sitter-topas/test/corpus/expressions.inp
@@ -2,184 +2,204 @@
 Simple expressions
 ==================
 
-x1 = 5;
-new_var = 1 /old_var;
-subtraction = x - 5;
-addition = 5 + x;
-exponentiation = 15.2 ^ x;
+prm x = 5;
+prm new_var = 1 /old_var;
+local subtraction = x - 5;
+prm addition = 5 + x;
+existing_prm exponentiation = 15.2 ^ x;
 
 ------------------
 (source_file
-  (identifier)
-  (simple_assignment
-    (integer_literal))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (integer_literal)
-      (identifier)))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (identifier)
+  (variable_declaration
+    (identifier)
+    (simple_assignment
       (integer_literal)))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (integer_literal)
-      (identifier)))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (float_literal)
-      (identifier))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (integer_literal)
+        (identifier))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (identifier)
+        (integer_literal))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (integer_literal)
+        (identifier))))
+  (variable_assignment
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (float_literal)
+        (identifier)))))
 
 ==========================
 Binary operator precedence
 ==========================
 
-new_var *= old_var+1 / 2;
-new_var *= (old_var+1) * 2;
+existing_prm new_var *= old_var+1 / 2;
+existing_prm new_var *= (old_var+1) * 2;
 
 --------------------------
 (source_file
-  (identifier)
-  (compound_assignment
-    (binary_expression
-      (identifier)
+  (variable_assignment
+    (identifier)
+    (compound_assignment
       (binary_expression
-        (integer_literal)
-        (integer_literal))))
-  (identifier)
-  (compound_assignment
-    (binary_expression
-      (parenthesised_expression
+        (identifier)
         (binary_expression
-          (identifier)
-          (integer_literal)))
-      (integer_literal))))
+          (integer_literal)
+          (integer_literal)))))
+  (variable_assignment
+    (identifier)
+    (compound_assignment
+      (binary_expression
+        (parenthesised_expression
+          (binary_expression
+            (identifier)
+            (integer_literal)))
+        (integer_literal)))))
 
 =========================
 Unary operator precedence
 =========================
-maths = - a1 * b2;
-exponent = -a2 ^ 3;
-multiply = a4 * - b5;
-negative_parentheses = - (a_variable);
-unary_subtraction = - 5 - 5;
-unary_exponent = x ^ +y;
+prm maths = - a1 * b2;
+prm exponent = -a2 ^ 3;
+prm multiply = a4 * - b5;
+prm negative_parentheses = - (a_variable);
+prm unary_subtraction = - 5 - 5;
+prm unary_exponent = x ^ +y;
 
 -------------------------
 (source_file
-  (identifier)
+  (variable_declaration
+    (identifier)
     (simple_assignment
-      (binary_expression
-        (unary_expression
-          (identifier))
-        (identifier)))
+        (binary_expression
+          (unary_expression
+            (identifier))
+          (identifier))))
+  (variable_declaration
     (identifier)
     (simple_assignment
       (unary_expression
         (binary_expression
           (identifier)
-          (integer_literal))))
-    (identifier)
-    (simple_assignment
-      (binary_expression
-        (identifier)
-        (unary_expression
-          (identifier))))
-    (identifier)
-    (simple_assignment
-      (unary_expression
-        (parenthesised_expression
-          (identifier))))
-    (identifier)
-    (simple_assignment
-      (binary_expression
-        (unary_expression
-          (integer_literal))
-        (integer_literal)))
+          (integer_literal)))))
+  (variable_declaration
     (identifier)
     (simple_assignment
       (binary_expression
         (identifier)
         (unary_expression
           (identifier)))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (unary_expression
+        (parenthesised_expression
+          (identifier)))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (unary_expression
+          (integer_literal))
+        (integer_literal))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (identifier)
+        (unary_expression
+          (identifier))))))
 
 =======================
 Implicit multiplication
 =======================
 
-implicit = var1 var2;
-implicit = var1 var2 ^ 3.2;
-ident_test = var1 (var2);
-macro_test = var1(var2);
-parentheses = (12.5/2) (var1 + 8);
-as_second_term = first_param / second_param 13.37;
+prm implicit = var1 var2;
+prm implicit = var1 var2 ^ 3.2;
+prm ident_test = var1 (var2);
+prm macro_test = var1(var2);
+prm parentheses = (12.5/2) (var1 + 8);
+prm as_second_term = first_param / second_param 13.37;
 
 -----------------------
 (source_file
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (identifier)
-      (identifier)))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (identifier)
+  (variable_declaration
+    (identifier)
+    (simple_assignment
       (binary_expression
         (identifier)
-        (float_literal))))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (identifier)
-      (parenthesised_expression
         (identifier))))
-  (identifier)
-  (simple_assignment
-    (macro_invocation
-      (identifier)
-      (argument_list
-        (identifier))))
-  (identifier)
-  (simple_assignment
-    (binary_expression
-      (parenthesised_expression
-        (binary_expression
-          (float_literal)
-          (integer_literal)))
-      (parenthesised_expression
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (identifier)
         (binary_expression
           (identifier)
-          (integer_literal)))))
-  (identifier)
-  (simple_assignment
-    (binary_expression
+          (float_literal)))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
       (binary_expression
         (identifier)
-        (identifier))
-      (float_literal))))
+        (parenthesised_expression
+          (identifier)))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (macro_invocation
+        (identifier)
+        (argument_list
+          (identifier)))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (parenthesised_expression
+          (binary_expression
+            (float_literal)
+            (integer_literal)))
+        (parenthesised_expression
+          (binary_expression
+            (identifier)
+            (integer_literal))))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (binary_expression
+        (binary_expression
+          (identifier)
+          (identifier))
+        (float_literal)))))
 
 ==============================
 Expression as a macro argument
 ==============================
 
-eqn_params = Divide(a/b);
+prm eqn_params = Divide(a/b);
 
 ------------------------------
 
 (source_file
-  (identifier)
-  (simple_assignment
-    (macro_invocation
-      (identifier)
-      (argument_list
-        (binary_expression
-          (identifier)
-          (identifier))))))
+  (variable_declaration
+    (identifier)
+    (simple_assignment
+      (macro_invocation
+        (identifier)
+        (argument_list
+          (binary_expression
+            (identifier)
+            (identifier)))))))
 
 
 =================
@@ -187,6 +207,6 @@ Missing semicolon
 :error
 =================
 
-fail_test = 1 * 2
+prm fail_test = 1 * 2
 
 -----------------

--- a/tree-sitter-topas/test/corpus/keywords.inp
+++ b/tree-sitter-topas/test/corpus/keywords.inp
@@ -1,0 +1,37 @@
+=====================
+Variable declarations
+=====================
+
+prm variable -2.2
+prm a1 = 12;
+local var 5
+local b2 = 16 e;
+existing_prm c3 *= Its_a_macro(argu, ments);
+
+---------------------
+
+(source_file
+      (variable_declaration
+        (identifier)
+        (float_literal))
+      (variable_declaration
+        (identifier)
+        (simple_assignment
+          (integer_literal)))
+      (variable_declaration
+        (identifier)
+        (integer_literal))
+      (variable_declaration
+        (identifier)
+        (simple_assignment
+          (binary_expression
+            (integer_literal)
+            (identifier))))
+      (variable_assignment
+        (identifier)
+        (compound_assignment
+          (macro_invocation
+            (identifier)
+            (argument_list
+              (identifier)
+              (identifier))))))

--- a/tree-sitter-topas/test/corpus/macro_definition.inp
+++ b/tree-sitter-topas/test/corpus/macro_definition.inp
@@ -3,7 +3,7 @@ Macro Declarations
 ==================
 
 macro My_macro(& var1, var2){
-    a = 5 * 2; : 0 
+    prm a1 = 5 * 2; : 0 
     activate PI
 } 
 macro name {}
@@ -16,12 +16,13 @@ macro name {}
         (parameter_list
             (identifier)
             (identifier))
-        (definition)
-        (simple_assignment
-            (binary_expression
-                (integer_literal)
-                (integer_literal))
-        (integer_literal))
+        (variable_declaration
+            (identifier)
+            (simple_assignment
+                (binary_expression
+                    (integer_literal)
+                    (integer_literal))
+            (integer_literal)))
         (definition)
         (identifier))
     (macro_declaration

--- a/tree-sitter-topas/test/corpus/preprocessor.inp
+++ b/tree-sitter-topas/test/corpus/preprocessor.inp
@@ -56,6 +56,20 @@ Output
         (identifier))
       (integer_literal))
 
+=================================
+Preprocessor variable declaration
+=================================
+
+#prm a1 = "a_string";
+
+---------------------------------
+
+(source_file
+    (preprocessor_variable_declaration
+        (identifier)
+        (simple_assignment
+            (string_literal))))
+
 ============================
 Macro directive if statement
 ============================
@@ -114,14 +128,14 @@ macro TEST(arg1) {
         (macro_if_statement
           (identifier)
           (string_literal)
-          (identifier)
-          (simple_assignment
-            (integer_literal)))
+            (identifier)
+            (simple_assignment
+                (integer_literal)))
         (macro_if_statement
-          (identifier)
-          (identifier)
-          (simple_assignment
-            (integer_literal)))))
+            (identifier)
+            (identifier)
+            (simple_assignment
+                (integer_literal)))))
 
 ========================
 Macro directive operator


### PR DESCRIPTION
Variables can be explicitly declared in TOPAS using either the `local` or `prm` keywords. Once declared, variables can be modified using the `existing_prm` keyword. This keyword allows compound assignment operators to be used (`+=`, `*=` etc.).

This PR implements these features under a new rule (potentially to become a `supertype` in future?) called `_keyword_statement` that replaces `$._equation` under the top-level `source_file` rule. 

Additionally, preprocessor parameters (defined using the `#prm` directive) can be declared in much the same way as ordinary parameters. 

The test corpus is updated to match the new grammar - standalone equations are no longer permitted as a top-level item, so keywords are added to all occurrences.

