### PR TITLE
Pre-generated parser files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-src/
 bindings/
 Cargo.toml
 binding.gyp

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/
 bindings/
 Cargo.toml
 binding.gyp
+build/

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,0 +1,4290 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
+  "name": "topas",
+  "rules": {
+    "source_file": {
+      "type": "REPEAT",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "macro_invocation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_keyword_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "definition"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_literal"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_global_preprocessor_directive"
+          }
+        ]
+      }
+    },
+    "line_comment": {
+      "type": "PATTERN",
+      "value": "'.*"
+    },
+    "block_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/*"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "PATTERN",
+            "value": "."
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "*/"
+        }
+      ]
+    },
+    "_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        }
+      ]
+    },
+    "string_literal": {
+      "type": "PATTERN",
+      "value": "\".*\""
+    },
+    "integer_literal": {
+      "type": "PATTERN",
+      "value": "-?\\d+"
+    },
+    "float_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "-?\\d*\\.\\d+"
+        },
+        {
+          "type": "PATTERN",
+          "value": "-?\\d+(\\.\\d+)?(e|E)-?\\d+(\\.\\d+)?"
+        }
+      ]
+    },
+    "macro_invocation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "arguments",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "argument_list"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "identifier": {
+      "type": "PATTERN",
+      "value": "[A-Za-z]\\w*"
+    },
+    "_argument": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "refined_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unrefined_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        }
+      ]
+    },
+    "argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "("
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_argument"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_argument"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "refined_parameter": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "@"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "integer_literal"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "float_literal"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "unrefined_parameter": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "!"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_literal"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_refineable_value_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "simple_assignment"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "@"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "!"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_literal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "_fixed_value_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "simple_assignment"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_literal"
+            }
+          ]
+        }
+      ]
+    },
+    "simple_assignment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "operator",
+          "content": {
+            "type": "STRING",
+            "value": "="
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "float_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "integer_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "compound_assignment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "operator",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "+="
+              },
+              {
+                "type": "STRING",
+                "value": "-="
+              },
+              {
+                "type": "STRING",
+                "value": "*="
+              },
+              {
+                "type": "STRING",
+                "value": "/="
+              },
+              {
+                "type": "STRING",
+                "value": "^="
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "float_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "integer_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_closed_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unary_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "binary_expression"
+        }
+      ]
+    },
+    "_closed_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_invocation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parenthesised_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_literal"
+        }
+      ]
+    },
+    "_exponentiation": {
+      "type": "PREC_LEFT",
+      "value": 5,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "left",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_closed_expression"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_exponentiation"
+                  },
+                  "named": true,
+                  "value": "binary_expression"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "STRING",
+              "value": "^"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "right",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expression"
+            }
+          }
+        ]
+      }
+    },
+    "binary_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_exponentiation"
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 3,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "*"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "/"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "%"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 3,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_closed_expression"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "_exponentiation"
+                      },
+                      "named": true,
+                      "value": "binary_expression"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 2,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "+"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "-"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "=="
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "<"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ">"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "<="
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ">="
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "unary_expression": {
+      "type": "PREC_RIGHT",
+      "value": 4,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "operator",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "+"
+                },
+                {
+                  "type": "STRING",
+                  "value": "-"
+                }
+              ]
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "argument",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "parenthesised_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "float_literal"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "integer_literal"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_exponentiation"
+                  },
+                  "named": true,
+                  "value": "binary_expression"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "parenthesised_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_block_item": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "definition"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_global_preprocessor_directive"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_keyword_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "refined_parameter"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "unrefined_parameter"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "simple_assignment"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "compound_assignment"
+          }
+        ]
+      }
+    },
+    "parameter_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "("
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "&"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "macro_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "macro"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "&"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "parameter_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_block_item"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_macro_preprocessor_directive"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "_global_preprocessor_directive": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "macro_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_include"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_delete"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_define"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_if_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_variable_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preprocessor_output"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_list"
+        }
+      ]
+    },
+    "preprocessor_include": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#include"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "path",
+          "content": {
+            "type": "SYMBOL",
+            "name": "string_literal"
+          }
+        }
+      ]
+    },
+    "preprocessor_delete": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#delete_macros"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "arguments",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "preprocessor_define": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#define"
+              },
+              {
+                "type": "STRING",
+                "value": "#undef"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+    "preprocessor_call": {
+      "type": "FIELD",
+      "name": "directive",
+      "content": {
+        "type": "STRING",
+        "value": "#seed"
+      }
+    },
+    "preprocessor_if_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_preproc_if"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_preproc_ifdef"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_preproc_ifndef"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_preproc_elseif"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_preproc_else"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#endif"
+          }
+        }
+      ]
+    },
+    "_preproc_if": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#if"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_preproc_ifdef": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#ifdef"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "!"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_preproc_ifndef": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#ifndef"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_preproc_elseif": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#elseif"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "condition",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_preproc_else": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#else"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "macro_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#list"
+          }
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "&"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "name",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "parameters",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "parameter_list"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_literal"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "refined_parameter"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "unrefined_parameter"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "delimited_block"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "delimited_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_macro_preprocessor_directive"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "preprocessor_variable_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#prm"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "simple_assignment"
+          }
+        }
+      ]
+    },
+    "preprocessor_output": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#out"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+    "_macro_preprocessor_directive": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "macro_if_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_operator_directive"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_macro_unique"
+          },
+          "named": true,
+          "value": "macro_operator_directive"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "macro_parameter_output"
+        }
+      ]
+    },
+    "macro_if_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_m_if"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_m_ifarg"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_m_elseif"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_m_else"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#m_endif"
+          }
+        }
+      ]
+    },
+    "_m_if": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#m_if"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "binary_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_m_elseif": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#m_elseif"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "binary_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_m_ifarg": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#m_ifarg"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "directive",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "#m_code"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "#_eqn"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "#m_code_refine"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "#m_one_word"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "string_literal"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "_m_else": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#m_else"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_block_item"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "macro_operator_directive": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "#m_argu"
+              },
+              {
+                "type": "STRING",
+                "value": "#m_first_word"
+              },
+              {
+                "type": "STRING",
+                "value": "#m_unique_not_refine"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+    "_macro_unique": {
+      "type": "FIELD",
+      "name": "directive",
+      "content": {
+        "type": "STRING",
+        "value": "#m_unique"
+      }
+    },
+    "macro_parameter_output": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "directive",
+          "content": {
+            "type": "STRING",
+            "value": "#m_out"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "argument",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        }
+      ]
+    },
+    "_keyword_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "variable_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "variable_assignment"
+        }
+      ]
+    },
+    "variable_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "keyword",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "prm"
+              },
+              {
+                "type": "STRING",
+                "value": "local"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "@"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "!"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_literal"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "simple_assignment"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "variable_assignment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "keyword",
+          "content": {
+            "type": "STRING",
+            "value": "existing_prm"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "@"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "!"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "simple_assignment"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "compound_assignment"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "definition": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "a"
+        },
+        {
+          "type": "STRING",
+          "value": "aberration_range_change_allowed"
+        },
+        {
+          "type": "STRING",
+          "value": "accumulate_phases_and_save_to_file"
+        },
+        {
+          "type": "STRING",
+          "value": "accumulate_phases_when"
+        },
+        {
+          "type": "STRING",
+          "value": "activate"
+        },
+        {
+          "type": "STRING",
+          "value": "add_pop_1st_2nd_peak"
+        },
+        {
+          "type": "STRING",
+          "value": "add_to_cloud_N"
+        },
+        {
+          "type": "STRING",
+          "value": "add_to_cloud_when"
+        },
+        {
+          "type": "STRING",
+          "value": "add_to_phases_of_weak_reflections"
+        },
+        {
+          "type": "STRING",
+          "value": "adps"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_anti_bump"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_closest_N"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_exclude_eq_0"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_flatten_with_tollerance_of"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_no_self_interation"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_only_eq_0"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_radius"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_sites_1"
+        },
+        {
+          "type": "STRING",
+          "value": "ai_sites_2"
+        },
+        {
+          "type": "STRING",
+          "value": "al"
+        },
+        {
+          "type": "STRING",
+          "value": "amorphous_area"
+        },
+        {
+          "type": "STRING",
+          "value": "amorphous_phase"
+        },
+        {
+          "type": "STRING",
+          "value": "append_bond_lengths"
+        },
+        {
+          "type": "STRING",
+          "value": "append_cartesian"
+        },
+        {
+          "type": "STRING",
+          "value": "append_fractional"
+        },
+        {
+          "type": "STRING",
+          "value": "apply_exp_scale"
+        },
+        {
+          "type": "STRING",
+          "value": "approximate_A"
+        },
+        {
+          "type": "STRING",
+          "value": "atomic_interaction"
+        },
+        {
+          "type": "STRING",
+          "value": "atom_out"
+        },
+        {
+          "type": "STRING",
+          "value": "auto_scale"
+        },
+        {
+          "type": "STRING",
+          "value": "auto_sparse_CG"
+        },
+        {
+          "type": "STRING",
+          "value": "axial_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "axial_del"
+        },
+        {
+          "type": "STRING",
+          "value": "axial_n_beta"
+        },
+        {
+          "type": "STRING",
+          "value": "a_add"
+        },
+        {
+          "type": "STRING",
+          "value": "A_matrix"
+        },
+        {
+          "type": "STRING",
+          "value": "A_matrix_normalized"
+        },
+        {
+          "type": "STRING",
+          "value": "A_matrix_prm_filter"
+        },
+        {
+          "type": "STRING",
+          "value": "b"
+        },
+        {
+          "type": "STRING",
+          "value": "be"
+        },
+        {
+          "type": "STRING",
+          "value": "beq"
+        },
+        {
+          "type": "STRING",
+          "value": "bkg"
+        },
+        {
+          "type": "STRING",
+          "value": "bootstrap_errors"
+        },
+        {
+          "type": "STRING",
+          "value": "box_interaction"
+        },
+        {
+          "type": "STRING",
+          "value": "break_cycle_if_true"
+        },
+        {
+          "type": "STRING",
+          "value": "brindley_spherical_r_cm"
+        },
+        {
+          "type": "STRING",
+          "value": "bring_2nd_peak_to_top"
+        },
+        {
+          "type": "STRING",
+          "value": "broaden_peaks"
+        },
+        {
+          "type": "STRING",
+          "value": "b_add"
+        },
+        {
+          "type": "STRING",
+          "value": "c"
+        },
+        {
+          "type": "STRING",
+          "value": "calculate_Lam"
+        },
+        {
+          "type": "STRING",
+          "value": "capillary_diameter_mm"
+        },
+        {
+          "type": "STRING",
+          "value": "capillary_divergent_beam"
+        },
+        {
+          "type": "STRING",
+          "value": "capillary_parallel_beam"
+        },
+        {
+          "type": "STRING",
+          "value": "capillary_u_cm_inv"
+        },
+        {
+          "type": "STRING",
+          "value": "cell_mass"
+        },
+        {
+          "type": "STRING",
+          "value": "cell_volume"
+        },
+        {
+          "type": "STRING",
+          "value": "cf_hkl_file"
+        },
+        {
+          "type": "STRING",
+          "value": "cf_in_A_matrix"
+        },
+        {
+          "type": "STRING",
+          "value": "charge_flipping"
+        },
+        {
+          "type": "STRING",
+          "value": "chi2"
+        },
+        {
+          "type": "STRING",
+          "value": "chi2_convergence_criteria"
+        },
+        {
+          "type": "STRING",
+          "value": "chk_for_best"
+        },
+        {
+          "type": "STRING",
+          "value": "choose_from"
+        },
+        {
+          "type": "STRING",
+          "value": "choose_randomly"
+        },
+        {
+          "type": "STRING",
+          "value": "choose_to"
+        },
+        {
+          "type": "STRING",
+          "value": "circles_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_atomic_separation"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_atomic_separation"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_extract_and_save_xyzs"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_fit"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_formation_omit_rwps"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_gauss_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_gauss_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_I"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_load"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_load_fixed_starting"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_load_xyzs"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_load_xyzs"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_load_xyzs_omit_rwps"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_match_gauss_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_min_intensity"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_number_to_extract"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_N_to_extract"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_population"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_population"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_pre_randimize_add_to"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_save"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_save"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_save_match_xy"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_save_processed_xyzs"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_save_xyzs"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_save_xyzs"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_stay_within"
+        },
+        {
+          "type": "STRING",
+          "value": "cloud_try_accept"
+        },
+        {
+          "type": "STRING",
+          "value": "conserve_memory"
+        },
+        {
+          "type": "STRING",
+          "value": "consider_lattice_parameters"
+        },
+        {
+          "type": "STRING",
+          "value": "continue_after_convergence"
+        },
+        {
+          "type": "STRING",
+          "value": "convolute_X_recal"
+        },
+        {
+          "type": "STRING",
+          "value": "convolution_step"
+        },
+        {
+          "type": "STRING",
+          "value": "corrected_weight_percent"
+        },
+        {
+          "type": "STRING",
+          "value": "correct_for_atomic_scattering_factors"
+        },
+        {
+          "type": "STRING",
+          "value": "correct_for_temperature_effects"
+        },
+        {
+          "type": "STRING",
+          "value": "crystalline_area"
+        },
+        {
+          "type": "STRING",
+          "value": "current_peak_max_x"
+        },
+        {
+          "type": "STRING",
+          "value": "current_peak_min_x"
+        },
+        {
+          "type": "STRING",
+          "value": "C_matrix"
+        },
+        {
+          "type": "STRING",
+          "value": "C_matrix_normalized"
+        },
+        {
+          "type": "STRING",
+          "value": "d"
+        },
+        {
+          "type": "STRING",
+          "value": "def"
+        },
+        {
+          "type": "STRING",
+          "value": "default_I_attributes"
+        },
+        {
+          "type": "STRING",
+          "value": "degree_of_crystallinity"
+        },
+        {
+          "type": "STRING",
+          "value": "del"
+        },
+        {
+          "type": "STRING",
+          "value": "delete_observed_reflections"
+        },
+        {
+          "type": "STRING",
+          "value": "del_approx"
+        },
+        {
+          "type": "STRING",
+          "value": "determine_values_from_samples"
+        },
+        {
+          "type": "STRING",
+          "value": "displace"
+        },
+        {
+          "type": "STRING",
+          "value": "dont_merge_equivalent_reflections"
+        },
+        {
+          "type": "STRING",
+          "value": "dont_merge_Friedel_pairs"
+        },
+        {
+          "type": "STRING",
+          "value": "do_errors"
+        },
+        {
+          "type": "STRING",
+          "value": "do_errors_include_penalties"
+        },
+        {
+          "type": "STRING",
+          "value": "do_errors_include_restraints"
+        },
+        {
+          "type": "STRING",
+          "value": "dummy"
+        },
+        {
+          "type": "STRING",
+          "value": "dummy_str"
+        },
+        {
+          "type": "STRING",
+          "value": "d_Is"
+        },
+        {
+          "type": "STRING",
+          "value": "elemental_composition"
+        },
+        {
+          "type": "STRING",
+          "value": "element_weight_percent"
+        },
+        {
+          "type": "STRING",
+          "value": "element_weight_percent_known"
+        },
+        {
+          "type": "STRING",
+          "value": "exclude"
+        },
+        {
+          "type": "STRING",
+          "value": "exp_conv_const"
+        },
+        {
+          "type": "STRING",
+          "value": "exp_limit"
+        },
+        {
+          "type": "STRING",
+          "value": "extend_calculated_sphere_to"
+        },
+        {
+          "type": "STRING",
+          "value": "extra_X"
+        },
+        {
+          "type": "STRING",
+          "value": "extra_X_left"
+        },
+        {
+          "type": "STRING",
+          "value": "extra_X_right"
+        },
+        {
+          "type": "STRING",
+          "value": "f0"
+        },
+        {
+          "type": "STRING",
+          "value": "f0_f1_f11_atom"
+        },
+        {
+          "type": "STRING",
+          "value": "f11"
+        },
+        {
+          "type": "STRING",
+          "value": "f1"
+        },
+        {
+          "type": "STRING",
+          "value": "filament_length"
+        },
+        {
+          "type": "STRING",
+          "value": "file_out"
+        },
+        {
+          "type": "STRING",
+          "value": "find_origin"
+        },
+        {
+          "type": "STRING",
+          "value": "finish_X"
+        },
+        {
+          "type": "STRING",
+          "value": "fit_obj"
+        },
+        {
+          "type": "STRING",
+          "value": "fit_obj_phase"
+        },
+        {
+          "type": "STRING",
+          "value": "Flack"
+        },
+        {
+          "type": "STRING",
+          "value": "flat_crystal_pre_monochromator_axial_const"
+        },
+        {
+          "type": "STRING",
+          "value": "flip_equation"
+        },
+        {
+          "type": "STRING",
+          "value": "flip_neutron"
+        },
+        {
+          "type": "STRING",
+          "value": "flip_regime_2"
+        },
+        {
+          "type": "STRING",
+          "value": "flip_regime_3"
+        },
+        {
+          "type": "STRING",
+          "value": "fn"
+        },
+        {
+          "type": "STRING",
+          "value": "fourier_map"
+        },
+        {
+          "type": "STRING",
+          "value": "fourier_map_formula"
+        },
+        {
+          "type": "STRING",
+          "value": "fo_transform_X"
+        },
+        {
+          "type": "STRING",
+          "value": "fraction_density_to_flip"
+        },
+        {
+          "type": "STRING",
+          "value": "fraction_of_yobs_to_resample"
+        },
+        {
+          "type": "STRING",
+          "value": "fraction_reflections_weak"
+        },
+        {
+          "type": "STRING",
+          "value": "ft_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "ft_convolution"
+        },
+        {
+          "type": "STRING",
+          "value": "ft_L_max"
+        },
+        {
+          "type": "STRING",
+          "value": "ft_min"
+        },
+        {
+          "type": "STRING",
+          "value": "ft_x_axis_range"
+        },
+        {
+          "type": "STRING",
+          "value": "fullprof_format"
+        },
+        {
+          "type": "STRING",
+          "value": "f_atom_quantity"
+        },
+        {
+          "type": "STRING",
+          "value": "f_atom_type"
+        },
+        {
+          "type": "STRING",
+          "value": "ga"
+        },
+        {
+          "type": "STRING",
+          "value": "gauss_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "generate_name_append"
+        },
+        {
+          "type": "STRING",
+          "value": "generate_stack_sequences"
+        },
+        {
+          "type": "STRING",
+          "value": "generate_these"
+        },
+        {
+          "type": "STRING",
+          "value": "gof"
+        },
+        {
+          "type": "STRING",
+          "value": "grs_interaction"
+        },
+        {
+          "type": "STRING",
+          "value": "gsas_format"
+        },
+        {
+          "type": "STRING",
+          "value": "gui_add_bkg"
+        },
+        {
+          "type": "STRING",
+          "value": "h1"
+        },
+        {
+          "type": "STRING",
+          "value": "h2"
+        },
+        {
+          "type": "STRING",
+          "value": "half_hat"
+        },
+        {
+          "type": "STRING",
+          "value": "hat"
+        },
+        {
+          "type": "STRING",
+          "value": "hat_height"
+        },
+        {
+          "type": "STRING",
+          "value": "height"
+        },
+        {
+          "type": "STRING",
+          "value": "histogram_match_scale_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "hklis"
+        },
+        {
+          "type": "STRING",
+          "value": "hkl_Is"
+        },
+        {
+          "type": "STRING",
+          "value": "hkl_m_d_th2"
+        },
+        {
+          "type": "STRING",
+          "value": "hkl_Re_Im"
+        },
+        {
+          "type": "STRING",
+          "value": "hm_covalent_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "hm_size_limit_in_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "I"
+        },
+        {
+          "type": "STRING",
+          "value": "ignore_differences_in_Friedel_pairs"
+        },
+        {
+          "type": "STRING",
+          "value": "index_d"
+        },
+        {
+          "type": "STRING",
+          "value": "index_exclude_max_on_min_lp_less_than"
+        },
+        {
+          "type": "STRING",
+          "value": "index_I"
+        },
+        {
+          "type": "STRING",
+          "value": "index_lam"
+        },
+        {
+          "type": "STRING",
+          "value": "index_max_lp"
+        },
+        {
+          "type": "STRING",
+          "value": "index_max_Nc_on_No"
+        },
+        {
+          "type": "STRING",
+          "value": "index_max_number_of_solutions"
+        },
+        {
+          "type": "STRING",
+          "value": "index_max_th2_error"
+        },
+        {
+          "type": "STRING",
+          "value": "index_max_zero_error"
+        },
+        {
+          "type": "STRING",
+          "value": "index_min_lp"
+        },
+        {
+          "type": "STRING",
+          "value": "index_th2"
+        },
+        {
+          "type": "STRING",
+          "value": "index_th2_resolution"
+        },
+        {
+          "type": "STRING",
+          "value": "index_x0"
+        },
+        {
+          "type": "STRING",
+          "value": "index_zero_error"
+        },
+        {
+          "type": "STRING",
+          "value": "insert"
+        },
+        {
+          "type": "STRING",
+          "value": "inter"
+        },
+        {
+          "type": "STRING",
+          "value": "in_cartesian"
+        },
+        {
+          "type": "STRING",
+          "value": "in_FC"
+        },
+        {
+          "type": "STRING",
+          "value": "in_str_format"
+        },
+        {
+          "type": "STRING",
+          "value": "iters"
+        },
+        {
+          "type": "STRING",
+          "value": "i_on_error_ratio_tolerance"
+        },
+        {
+          "type": "STRING",
+          "value": "I_parameter_names_have_hkl"
+        },
+        {
+          "type": "STRING",
+          "value": "la"
+        },
+        {
+          "type": "STRING",
+          "value": "Lam"
+        },
+        {
+          "type": "STRING",
+          "value": "lam"
+        },
+        {
+          "type": "STRING",
+          "value": "layer"
+        },
+        {
+          "type": "STRING",
+          "value": "layers_tol"
+        },
+        {
+          "type": "STRING",
+          "value": "lebail"
+        },
+        {
+          "type": "STRING",
+          "value": "lg"
+        },
+        {
+          "type": "STRING",
+          "value": "lh"
+        },
+        {
+          "type": "STRING",
+          "value": "line_min"
+        },
+        {
+          "type": "STRING",
+          "value": "lo"
+        },
+        {
+          "type": "STRING",
+          "value": "load"
+        },
+        {
+          "type": "STRING",
+          "value": "lor_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "lpsd_beam_spill_correct_intensity"
+        },
+        {
+          "type": "STRING",
+          "value": "lpsd_equitorial_divergence_degrees"
+        },
+        {
+          "type": "STRING",
+          "value": "lpsd_equitorial_sample_length_mm"
+        },
+        {
+          "type": "STRING",
+          "value": "lpsd_th2_angular_range_degrees"
+        },
+        {
+          "type": "STRING",
+          "value": "lp_search"
+        },
+        {
+          "type": "STRING",
+          "value": "m1"
+        },
+        {
+          "type": "STRING",
+          "value": "m2"
+        },
+        {
+          "type": "STRING",
+          "value": "mag_atom_out"
+        },
+        {
+          "type": "STRING",
+          "value": "mag_only"
+        },
+        {
+          "type": "STRING",
+          "value": "mag_only_for_mag_sites"
+        },
+        {
+          "type": "STRING",
+          "value": "mag_space_group"
+        },
+        {
+          "type": "STRING",
+          "value": "marquardt_constant"
+        },
+        {
+          "type": "STRING",
+          "value": "match_transition_matrix_stats"
+        },
+        {
+          "type": "STRING",
+          "value": "max"
+        },
+        {
+          "type": "STRING",
+          "value": "max_r"
+        },
+        {
+          "type": "STRING",
+          "value": "max_X"
+        },
+        {
+          "type": "STRING",
+          "value": "mg"
+        },
+        {
+          "type": "STRING",
+          "value": "min"
+        },
+        {
+          "type": "STRING",
+          "value": "min_d"
+        },
+        {
+          "type": "STRING",
+          "value": "min_grid_spacing"
+        },
+        {
+          "type": "STRING",
+          "value": "min_r"
+        },
+        {
+          "type": "STRING",
+          "value": "min_X"
+        },
+        {
+          "type": "STRING",
+          "value": "mixture_density_g_on_cm3"
+        },
+        {
+          "type": "STRING",
+          "value": "mixture_MAC"
+        },
+        {
+          "type": "STRING",
+          "value": "mlx"
+        },
+        {
+          "type": "STRING",
+          "value": "mly"
+        },
+        {
+          "type": "STRING",
+          "value": "mlz"
+        },
+        {
+          "type": "STRING",
+          "value": "modify_initial_phases"
+        },
+        {
+          "type": "STRING",
+          "value": "modify_peak"
+        },
+        {
+          "type": "STRING",
+          "value": "modify_peak_apply_before_convolutions"
+        },
+        {
+          "type": "STRING",
+          "value": "modify_peak_eqn"
+        },
+        {
+          "type": "STRING",
+          "value": "more_accurate_Voigt"
+        },
+        {
+          "type": "STRING",
+          "value": "move_to"
+        },
+        {
+          "type": "STRING",
+          "value": "move_to_the_next_temperature_regardless_of_the_change_in_rwp"
+        },
+        {
+          "type": "STRING",
+          "value": "n1"
+        },
+        {
+          "type": "STRING",
+          "value": "n2"
+        },
+        {
+          "type": "STRING",
+          "value": "n3"
+        },
+        {
+          "type": "STRING",
+          "value": "n"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_allp"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_alp"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_belp"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_blp"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_clp"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_galp"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_gof"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_sg"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_uni"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_vol"
+        },
+        {
+          "type": "STRING",
+          "value": "ndx_ze"
+        },
+        {
+          "type": "STRING",
+          "value": "neutron_data"
+        },
+        {
+          "type": "STRING",
+          "value": "normalize_FCs"
+        },
+        {
+          "type": "STRING",
+          "value": "normals_plot"
+        },
+        {
+          "type": "STRING",
+          "value": "normals_plot_min_d"
+        },
+        {
+          "type": "STRING",
+          "value": "no_f11"
+        },
+        {
+          "type": "STRING",
+          "value": "no_inline"
+        },
+        {
+          "type": "STRING",
+          "value": "no_LIMIT_warnings"
+        },
+        {
+          "type": "STRING",
+          "value": "no_normal_equations"
+        },
+        {
+          "type": "STRING",
+          "value": "no_th_dependence"
+        },
+        {
+          "type": "STRING",
+          "value": "number_of_sequences"
+        },
+        {
+          "type": "STRING",
+          "value": "number_of_stacks_per_sequence"
+        },
+        {
+          "type": "STRING",
+          "value": "numerical_area"
+        },
+        {
+          "type": "STRING",
+          "value": "numerical_lor_gauss_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "numerical_lor_ymin_on_ymax"
+        },
+        {
+          "type": "STRING",
+          "value": "num_hats"
+        },
+        {
+          "type": "STRING",
+          "value": "num_highest_I_values_to_keep"
+        },
+        {
+          "type": "STRING",
+          "value": "num_patterns_at_a_time"
+        },
+        {
+          "type": "STRING",
+          "value": "num_posns"
+        },
+        {
+          "type": "STRING",
+          "value": "num_runs"
+        },
+        {
+          "type": "STRING",
+          "value": "num_unique_vx_vy"
+        },
+        {
+          "type": "STRING",
+          "value": "n_avg"
+        },
+        {
+          "type": "STRING",
+          "value": "occ"
+        },
+        {
+          "type": "STRING",
+          "value": "occ_merge"
+        },
+        {
+          "type": "STRING",
+          "value": "occ_merge_radius"
+        },
+        {
+          "type": "STRING",
+          "value": "omit"
+        },
+        {
+          "type": "STRING",
+          "value": "omit_hkls"
+        },
+        {
+          "type": "STRING",
+          "value": "one_on_x_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "only_lps"
+        },
+        {
+          "type": "STRING",
+          "value": "only_penalties"
+        },
+        {
+          "type": "STRING",
+          "value": "on_best_goto"
+        },
+        {
+          "type": "STRING",
+          "value": "on_best_rewind"
+        },
+        {
+          "type": "STRING",
+          "value": "operate_on_points"
+        },
+        {
+          "type": "STRING",
+          "value": "out"
+        },
+        {
+          "type": "STRING",
+          "value": "out_A_matrix"
+        },
+        {
+          "type": "STRING",
+          "value": "out_chi2"
+        },
+        {
+          "type": "STRING",
+          "value": "out_dependences"
+        },
+        {
+          "type": "STRING",
+          "value": "out_dependents_for"
+        },
+        {
+          "type": "STRING",
+          "value": "out_eqn"
+        },
+        {
+          "type": "STRING",
+          "value": "out_file"
+        },
+        {
+          "type": "STRING",
+          "value": "out_fmt"
+        },
+        {
+          "type": "STRING",
+          "value": "out_fmt_err"
+        },
+        {
+          "type": "STRING",
+          "value": "out_prm_vals_dependents_filter"
+        },
+        {
+          "type": "STRING",
+          "value": "out_prm_vals_filter"
+        },
+        {
+          "type": "STRING",
+          "value": "out_prm_vals_on_convergence"
+        },
+        {
+          "type": "STRING",
+          "value": "out_prm_vals_per_iteration"
+        },
+        {
+          "type": "STRING",
+          "value": "out_record"
+        },
+        {
+          "type": "STRING",
+          "value": "out_refinement_stats"
+        },
+        {
+          "type": "STRING",
+          "value": "out_rwp"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_convolute"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_data"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_for_pairs"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_gauss_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_info"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_only_eq_0"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_scale_simple"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_ymin_on_ymax"
+        },
+        {
+          "type": "STRING",
+          "value": "pdf_zero"
+        },
+        {
+          "type": "STRING",
+          "value": "peak_buffer_based_on"
+        },
+        {
+          "type": "STRING",
+          "value": "peak_buffer_based_on_tol"
+        },
+        {
+          "type": "STRING",
+          "value": "peak_buffer_step"
+        },
+        {
+          "type": "STRING",
+          "value": "peak_type"
+        },
+        {
+          "type": "STRING",
+          "value": "penalties_weighting_K1"
+        },
+        {
+          "type": "STRING",
+          "value": "penalty"
+        },
+        {
+          "type": "STRING",
+          "value": "pen_weight"
+        },
+        {
+          "type": "STRING",
+          "value": "percent_zeros_before_sparse_A"
+        },
+        {
+          "type": "STRING",
+          "value": "phase_MAC"
+        },
+        {
+          "type": "STRING",
+          "value": "phase_name"
+        },
+        {
+          "type": "STRING",
+          "value": "phase_out"
+        },
+        {
+          "type": "STRING",
+          "value": "phase_penalties"
+        },
+        {
+          "type": "STRING",
+          "value": "pick_atoms"
+        },
+        {
+          "type": "STRING",
+          "value": "pick_atoms_when"
+        },
+        {
+          "type": "STRING",
+          "value": "pk_xo"
+        },
+        {
+          "type": "STRING",
+          "value": "point_for_site"
+        },
+        {
+          "type": "STRING",
+          "value": "primary_soller_angle"
+        },
+        {
+          "type": "STRING",
+          "value": "prm_with_error"
+        },
+        {
+          "type": "STRING",
+          "value": "process_times"
+        },
+        {
+          "type": "STRING",
+          "value": "pr_str"
+        },
+        {
+          "type": "STRING",
+          "value": "push_peak"
+        },
+        {
+          "type": "STRING",
+          "value": "pv_fwhm"
+        },
+        {
+          "type": "STRING",
+          "value": "pv_lor"
+        },
+        {
+          "type": "STRING",
+          "value": "qa"
+        },
+        {
+          "type": "STRING",
+          "value": "qb"
+        },
+        {
+          "type": "STRING",
+          "value": "qc"
+        },
+        {
+          "type": "STRING",
+          "value": "quick_refine"
+        },
+        {
+          "type": "STRING",
+          "value": "quick_refine_remove"
+        },
+        {
+          "type": "STRING",
+          "value": "qx"
+        },
+        {
+          "type": "STRING",
+          "value": "qy"
+        },
+        {
+          "type": "STRING",
+          "value": "qz"
+        },
+        {
+          "type": "STRING",
+          "value": "randomize_initial_phases_by"
+        },
+        {
+          "type": "STRING",
+          "value": "randomize_on_errors"
+        },
+        {
+          "type": "STRING",
+          "value": "randomize_phases_on_new_cycle_by"
+        },
+        {
+          "type": "STRING",
+          "value": "rand_xyz"
+        },
+        {
+          "type": "STRING",
+          "value": "range"
+        },
+        {
+          "type": "STRING",
+          "value": "rebin_min_merge"
+        },
+        {
+          "type": "STRING",
+          "value": "rebin_tollerance_in_Y"
+        },
+        {
+          "type": "STRING",
+          "value": "rebin_with_dx_of"
+        },
+        {
+          "type": "STRING",
+          "value": "recal_weighting_on_iter"
+        },
+        {
+          "type": "STRING",
+          "value": "receiving_slit_length"
+        },
+        {
+          "type": "STRING",
+          "value": "redo_hkls"
+        },
+        {
+          "type": "STRING",
+          "value": "remove_phase"
+        },
+        {
+          "type": "STRING",
+          "value": "report_on"
+        },
+        {
+          "type": "STRING",
+          "value": "report_on_str"
+        },
+        {
+          "type": "STRING",
+          "value": "resample_from_current_ycalc"
+        },
+        {
+          "type": "STRING",
+          "value": "restraint"
+        },
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "STRING",
+          "value": "rigid"
+        },
+        {
+          "type": "STRING",
+          "value": "rotate"
+        },
+        {
+          "type": "STRING",
+          "value": "Rp"
+        },
+        {
+          "type": "STRING",
+          "value": "Rs"
+        },
+        {
+          "type": "STRING",
+          "value": "r_bragg"
+        },
+        {
+          "type": "STRING",
+          "value": "r_exp"
+        },
+        {
+          "type": "STRING",
+          "value": "r_exp_dash"
+        },
+        {
+          "type": "STRING",
+          "value": "r_p"
+        },
+        {
+          "type": "STRING",
+          "value": "r_p_dash"
+        },
+        {
+          "type": "STRING",
+          "value": "r_wp"
+        },
+        {
+          "type": "STRING",
+          "value": "r_wp_dash"
+        },
+        {
+          "type": "STRING",
+          "value": "r_wp_normal"
+        },
+        {
+          "type": "STRING",
+          "value": "sample_length"
+        },
+        {
+          "type": "STRING",
+          "value": "save_best_chi2"
+        },
+        {
+          "type": "STRING",
+          "value": "save_sequences"
+        },
+        {
+          "type": "STRING",
+          "value": "save_sequences_as_strs"
+        },
+        {
+          "type": "STRING",
+          "value": "save_values_as_best_after_randomization"
+        },
+        {
+          "type": "STRING",
+          "value": "scale"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_Aij"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_density_below_threshold"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_E"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_F000"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_F"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_phases"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_phase_X"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_pks"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_top_peak"
+        },
+        {
+          "type": "STRING",
+          "value": "scale_weak_reflections"
+        },
+        {
+          "type": "STRING",
+          "value": "secondary_soller_angle"
+        },
+        {
+          "type": "STRING",
+          "value": "seed"
+        },
+        {
+          "type": "STRING",
+          "value": "set_initial_phases_to"
+        },
+        {
+          "type": "STRING",
+          "value": "sh_alpha"
+        },
+        {
+          "type": "STRING",
+          "value": "sh_Cij_prm"
+        },
+        {
+          "type": "STRING",
+          "value": "sh_order"
+        },
+        {
+          "type": "STRING",
+          "value": "site"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_angle"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_avg_rand_xyz"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_distance"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_flatten"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_geometry"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_rand_on_avg"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_rand_on_avg_distance_to_randomize"
+        },
+        {
+          "type": "STRING",
+          "value": "sites_rand_on_avg_min_distance"
+        },
+        {
+          "type": "STRING",
+          "value": "site_to_restrain"
+        },
+        {
+          "type": "STRING",
+          "value": "siv_s1_s2"
+        },
+        {
+          "type": "STRING",
+          "value": "smooth"
+        },
+        {
+          "type": "STRING",
+          "value": "space_group"
+        },
+        {
+          "type": "STRING",
+          "value": "sparse_A"
+        },
+        {
+          "type": "STRING",
+          "value": "spherical_harmonics_hkl"
+        },
+        {
+          "type": "STRING",
+          "value": "spiked_phase_measured_weight_percent"
+        },
+        {
+          "type": "STRING",
+          "value": "spv_h1"
+        },
+        {
+          "type": "STRING",
+          "value": "spv_h2"
+        },
+        {
+          "type": "STRING",
+          "value": "spv_l1"
+        },
+        {
+          "type": "STRING",
+          "value": "spv_l2"
+        },
+        {
+          "type": "STRING",
+          "value": "stack"
+        },
+        {
+          "type": "STRING",
+          "value": "stacked_hats_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "start_values_from_site"
+        },
+        {
+          "type": "STRING",
+          "value": "start_X"
+        },
+        {
+          "type": "STRING",
+          "value": "stop_when"
+        },
+        {
+          "type": "STRING",
+          "value": "str"
+        },
+        {
+          "type": "STRING",
+          "value": "strs"
+        },
+        {
+          "type": "STRING",
+          "value": "str_hkl_angle"
+        },
+        {
+          "type": "STRING",
+          "value": "str_hkl_smallest_angle"
+        },
+        {
+          "type": "STRING",
+          "value": "str_mass"
+        },
+        {
+          "type": "STRING",
+          "value": "str_mass"
+        },
+        {
+          "type": "STRING",
+          "value": "sx"
+        },
+        {
+          "type": "STRING",
+          "value": "sy"
+        },
+        {
+          "type": "STRING",
+          "value": "symmetry_obey_0_to_1"
+        },
+        {
+          "type": "STRING",
+          "value": "system_after_save_OUT"
+        },
+        {
+          "type": "STRING",
+          "value": "system_before_save_OUT"
+        },
+        {
+          "type": "STRING",
+          "value": "sz"
+        },
+        {
+          "type": "STRING",
+          "value": "ta"
+        },
+        {
+          "type": "STRING",
+          "value": "tag"
+        },
+        {
+          "type": "STRING",
+          "value": "tag_2"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_max_triplets_per_h"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_min_triplets_per_h"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_num_h_keep"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_num_h_read"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_num_k_read"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_scale_difference_by"
+        },
+        {
+          "type": "STRING",
+          "value": "tangent_tiny"
+        },
+        {
+          "type": "STRING",
+          "value": "tb"
+        },
+        {
+          "type": "STRING",
+          "value": "tc"
+        },
+        {
+          "type": "STRING",
+          "value": "temperature"
+        },
+        {
+          "type": "STRING",
+          "value": "test_a"
+        },
+        {
+          "type": "STRING",
+          "value": "test_al"
+        },
+        {
+          "type": "STRING",
+          "value": "test_b"
+        },
+        {
+          "type": "STRING",
+          "value": "test_be"
+        },
+        {
+          "type": "STRING",
+          "value": "test_c"
+        },
+        {
+          "type": "STRING",
+          "value": "test_ga"
+        },
+        {
+          "type": "STRING",
+          "value": "th2_offset"
+        },
+        {
+          "type": "STRING",
+          "value": "to"
+        },
+        {
+          "type": "STRING",
+          "value": "transition"
+        },
+        {
+          "type": "STRING",
+          "value": "translate"
+        },
+        {
+          "type": "STRING",
+          "value": "try_space_groups"
+        },
+        {
+          "type": "STRING",
+          "value": "two_theta_calibration"
+        },
+        {
+          "type": "STRING",
+          "value": "tx"
+        },
+        {
+          "type": "STRING",
+          "value": "ty"
+        },
+        {
+          "type": "STRING",
+          "value": "tz"
+        },
+        {
+          "type": "STRING",
+          "value": "u11"
+        },
+        {
+          "type": "STRING",
+          "value": "u12"
+        },
+        {
+          "type": "STRING",
+          "value": "u13"
+        },
+        {
+          "type": "STRING",
+          "value": "u22"
+        },
+        {
+          "type": "STRING",
+          "value": "u23"
+        },
+        {
+          "type": "STRING",
+          "value": "u33"
+        },
+        {
+          "type": "STRING",
+          "value": "ua"
+        },
+        {
+          "type": "STRING",
+          "value": "ub"
+        },
+        {
+          "type": "STRING",
+          "value": "uc"
+        },
+        {
+          "type": "STRING",
+          "value": "update"
+        },
+        {
+          "type": "STRING",
+          "value": "user_defined_convolution"
+        },
+        {
+          "type": "STRING",
+          "value": "user_threshold"
+        },
+        {
+          "type": "STRING",
+          "value": "user_y"
+        },
+        {
+          "type": "STRING",
+          "value": "use_best_values"
+        },
+        {
+          "type": "STRING",
+          "value": "use_CG"
+        },
+        {
+          "type": "STRING",
+          "value": "use_extrapolation"
+        },
+        {
+          "type": "STRING",
+          "value": "use_Fc"
+        },
+        {
+          "type": "STRING",
+          "value": "use_layer"
+        },
+        {
+          "type": "STRING",
+          "value": "use_LU"
+        },
+        {
+          "type": "STRING",
+          "value": "use_LU_for_errors"
+        },
+        {
+          "type": "STRING",
+          "value": "use_tube_dispersion_coefficients"
+        },
+        {
+          "type": "STRING",
+          "value": "ux"
+        },
+        {
+          "type": "STRING",
+          "value": "uy"
+        },
+        {
+          "type": "STRING",
+          "value": "uz"
+        },
+        {
+          "type": "STRING",
+          "value": "v1"
+        },
+        {
+          "type": "STRING",
+          "value": "val_on_continue"
+        },
+        {
+          "type": "STRING",
+          "value": "verbose"
+        },
+        {
+          "type": "STRING",
+          "value": "view_cloud"
+        },
+        {
+          "type": "STRING",
+          "value": "view_structure"
+        },
+        {
+          "type": "STRING",
+          "value": "volume"
+        },
+        {
+          "type": "STRING",
+          "value": "weighted_Durbin_Watson"
+        },
+        {
+          "type": "STRING",
+          "value": "weighting"
+        },
+        {
+          "type": "STRING",
+          "value": "weighting_normal"
+        },
+        {
+          "type": "STRING",
+          "value": "weight_percent"
+        },
+        {
+          "type": "STRING",
+          "value": "weight_percent_amorphous"
+        },
+        {
+          "type": "STRING",
+          "value": "whole_hat"
+        },
+        {
+          "type": "STRING",
+          "value": "WPPM_correct_Is"
+        },
+        {
+          "type": "STRING",
+          "value": "WPPM_ft_conv"
+        },
+        {
+          "type": "STRING",
+          "value": "WPPM_L_max"
+        },
+        {
+          "type": "STRING",
+          "value": "WPPM_th2_range"
+        },
+        {
+          "type": "STRING",
+          "value": "x"
+        },
+        {
+          "type": "STRING",
+          "value": "xdd"
+        },
+        {
+          "type": "STRING",
+          "value": "xdds"
+        },
+        {
+          "type": "STRING",
+          "value": "xdd_out"
+        },
+        {
+          "type": "STRING",
+          "value": "xdd_scr"
+        },
+        {
+          "type": "STRING",
+          "value": "xdd_sum"
+        },
+        {
+          "type": "STRING",
+          "value": "xo"
+        },
+        {
+          "type": "STRING",
+          "value": "xo_Is"
+        },
+        {
+          "type": "STRING",
+          "value": "xye_format"
+        },
+        {
+          "type": "STRING",
+          "value": "x_angle_scaler"
+        },
+        {
+          "type": "STRING",
+          "value": "x_axis_to_energy_in_eV"
+        },
+        {
+          "type": "STRING",
+          "value": "x_calculation_step"
+        },
+        {
+          "type": "STRING",
+          "value": "x_scaler"
+        },
+        {
+          "type": "STRING",
+          "value": "y"
+        },
+        {
+          "type": "STRING",
+          "value": "yc_eqn"
+        },
+        {
+          "type": "STRING",
+          "value": "ymin_on_ymax"
+        },
+        {
+          "type": "STRING",
+          "value": "yobs_eqn"
+        },
+        {
+          "type": "STRING",
+          "value": "yobs_to_xo_posn_yobs"
+        },
+        {
+          "type": "STRING",
+          "value": "z"
+        },
+        {
+          "type": "STRING",
+          "value": "z_add"
+        },
+        {
+          "type": "STRING",
+          "value": "z_matrix"
+        }
+      ]
+    }
+  },
+  "extras": [
+    {
+      "type": "PATTERN",
+      "value": "\\s|\\n"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "line_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
+    }
+  ],
+  "conflicts": [],
+  "precedences": [],
+  "externals": [],
+  "inline": [],
+  "supertypes": []
+}

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,0 +1,4039 @@
+[
+  {
+    "type": "argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "macro_invocation",
+          "named": true
+        },
+        {
+          "type": "parenthesised_expression",
+          "named": true
+        },
+        {
+          "type": "refined_parameter",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unrefined_parameter",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "binary_expression",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "macro_invocation",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "%",
+            "named": false
+          },
+          {
+            "type": "*",
+            "named": false
+          },
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          },
+          {
+            "type": "/",
+            "named": false
+          },
+          {
+            "type": "<",
+            "named": false
+          },
+          {
+            "type": "<=",
+            "named": false
+          },
+          {
+            "type": "==",
+            "named": false
+          },
+          {
+            "type": ">",
+            "named": false
+          },
+          {
+            "type": ">=",
+            "named": false
+          },
+          {
+            "type": "^",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "macro_invocation",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "block_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "compound_assignment",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "macro_invocation",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "*=",
+            "named": false
+          },
+          {
+            "type": "+=",
+            "named": false
+          },
+          {
+            "type": "-=",
+            "named": false
+          },
+          {
+            "type": "/=",
+            "named": false
+          },
+          {
+            "type": "^=",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "definition",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "delimited_block",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "compound_assignment",
+          "named": true
+        },
+        {
+          "type": "definition",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "macro_declaration",
+          "named": true
+        },
+        {
+          "type": "macro_if_statement",
+          "named": true
+        },
+        {
+          "type": "macro_invocation",
+          "named": true
+        },
+        {
+          "type": "macro_list",
+          "named": true
+        },
+        {
+          "type": "macro_operator_directive",
+          "named": true
+        },
+        {
+          "type": "macro_parameter_output",
+          "named": true
+        },
+        {
+          "type": "parenthesised_expression",
+          "named": true
+        },
+        {
+          "type": "preprocessor_call",
+          "named": true
+        },
+        {
+          "type": "preprocessor_define",
+          "named": true
+        },
+        {
+          "type": "preprocessor_delete",
+          "named": true
+        },
+        {
+          "type": "preprocessor_if_statement",
+          "named": true
+        },
+        {
+          "type": "preprocessor_include",
+          "named": true
+        },
+        {
+          "type": "preprocessor_output",
+          "named": true
+        },
+        {
+          "type": "preprocessor_variable_declaration",
+          "named": true
+        },
+        {
+          "type": "refined_parameter",
+          "named": true
+        },
+        {
+          "type": "simple_assignment",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unrefined_parameter",
+          "named": true
+        },
+        {
+          "type": "variable_assignment",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "float_literal",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "macro_declaration",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "compound_assignment",
+            "named": true
+          },
+          {
+            "type": "definition",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "macro_declaration",
+            "named": true
+          },
+          {
+            "type": "macro_if_statement",
+            "named": true
+          },
+          {
+            "type": "macro_invocation",
+            "named": true
+          },
+          {
+            "type": "macro_list",
+            "named": true
+          },
+          {
+            "type": "macro_operator_directive",
+            "named": true
+          },
+          {
+            "type": "macro_parameter_output",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          },
+          {
+            "type": "preprocessor_call",
+            "named": true
+          },
+          {
+            "type": "preprocessor_define",
+            "named": true
+          },
+          {
+            "type": "preprocessor_delete",
+            "named": true
+          },
+          {
+            "type": "preprocessor_if_statement",
+            "named": true
+          },
+          {
+            "type": "preprocessor_include",
+            "named": true
+          },
+          {
+            "type": "preprocessor_output",
+            "named": true
+          },
+          {
+            "type": "preprocessor_variable_declaration",
+            "named": true
+          },
+          {
+            "type": "refined_parameter",
+            "named": true
+          },
+          {
+            "type": "simple_assignment",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          },
+          {
+            "type": "unrefined_parameter",
+            "named": true
+          },
+          {
+            "type": "variable_assignment",
+            "named": true
+          },
+          {
+            "type": "variable_declaration",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "parameter_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "macro_if_statement",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "directive": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "#_eqn",
+            "named": false
+          },
+          {
+            "type": "#m_code",
+            "named": false
+          },
+          {
+            "type": "#m_code_refine",
+            "named": false
+          },
+          {
+            "type": "#m_else",
+            "named": false
+          },
+          {
+            "type": "#m_elseif",
+            "named": false
+          },
+          {
+            "type": "#m_endif",
+            "named": false
+          },
+          {
+            "type": "#m_if",
+            "named": false
+          },
+          {
+            "type": "#m_ifarg",
+            "named": false
+          },
+          {
+            "type": "#m_one_word",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "compound_assignment",
+          "named": true
+        },
+        {
+          "type": "definition",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "macro_declaration",
+          "named": true
+        },
+        {
+          "type": "macro_invocation",
+          "named": true
+        },
+        {
+          "type": "macro_list",
+          "named": true
+        },
+        {
+          "type": "parenthesised_expression",
+          "named": true
+        },
+        {
+          "type": "preprocessor_call",
+          "named": true
+        },
+        {
+          "type": "preprocessor_define",
+          "named": true
+        },
+        {
+          "type": "preprocessor_delete",
+          "named": true
+        },
+        {
+          "type": "preprocessor_if_statement",
+          "named": true
+        },
+        {
+          "type": "preprocessor_include",
+          "named": true
+        },
+        {
+          "type": "preprocessor_output",
+          "named": true
+        },
+        {
+          "type": "preprocessor_variable_declaration",
+          "named": true
+        },
+        {
+          "type": "refined_parameter",
+          "named": true
+        },
+        {
+          "type": "simple_assignment",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unrefined_parameter",
+          "named": true
+        },
+        {
+          "type": "variable_assignment",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "macro_invocation",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "macro_list",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "delimited_block",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "refined_parameter",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unrefined_parameter",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      },
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#list",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "parameter_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "macro_operator_directive",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "directive": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "#m_argu",
+            "named": false
+          },
+          {
+            "type": "#m_first_word",
+            "named": false
+          },
+          {
+            "type": "#m_unique",
+            "named": false
+          },
+          {
+            "type": "#m_unique_not_refine",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "macro_parameter_output",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#m_out",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "parameter_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "parenthesised_expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "macro_invocation",
+          "named": true
+        },
+        {
+          "type": "parenthesised_expression",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "preprocessor_call",
+    "named": true,
+    "fields": {
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#seed",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "preprocessor_define",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#define",
+            "named": false
+          },
+          {
+            "type": "#undef",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "preprocessor_delete",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      },
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#delete_macros",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "preprocessor_if_statement",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "condition": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "macro_invocation",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          }
+        ]
+      },
+      "directive": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "#else",
+            "named": false
+          },
+          {
+            "type": "#elseif",
+            "named": false
+          },
+          {
+            "type": "#endif",
+            "named": false
+          },
+          {
+            "type": "#if",
+            "named": false
+          },
+          {
+            "type": "#ifdef",
+            "named": false
+          },
+          {
+            "type": "#ifndef",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
+          "type": "compound_assignment",
+          "named": true
+        },
+        {
+          "type": "definition",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "macro_declaration",
+          "named": true
+        },
+        {
+          "type": "macro_invocation",
+          "named": true
+        },
+        {
+          "type": "macro_list",
+          "named": true
+        },
+        {
+          "type": "parenthesised_expression",
+          "named": true
+        },
+        {
+          "type": "preprocessor_call",
+          "named": true
+        },
+        {
+          "type": "preprocessor_define",
+          "named": true
+        },
+        {
+          "type": "preprocessor_delete",
+          "named": true
+        },
+        {
+          "type": "preprocessor_if_statement",
+          "named": true
+        },
+        {
+          "type": "preprocessor_include",
+          "named": true
+        },
+        {
+          "type": "preprocessor_output",
+          "named": true
+        },
+        {
+          "type": "preprocessor_variable_declaration",
+          "named": true
+        },
+        {
+          "type": "refined_parameter",
+          "named": true
+        },
+        {
+          "type": "simple_assignment",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
+          "named": true
+        },
+        {
+          "type": "unrefined_parameter",
+          "named": true
+        },
+        {
+          "type": "variable_assignment",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "preprocessor_include",
+    "named": true,
+    "fields": {
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#include",
+            "named": false
+          }
+        ]
+      },
+      "path": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "string_literal",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "preprocessor_output",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#out",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "preprocessor_variable_declaration",
+    "named": true,
+    "fields": {
+      "directive": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "#prm",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "simple_assignment",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "refined_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "simple_assignment",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "macro_invocation",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "=",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "source_file",
+    "named": true,
+    "root": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "definition",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "macro_declaration",
+          "named": true
+        },
+        {
+          "type": "macro_invocation",
+          "named": true
+        },
+        {
+          "type": "macro_list",
+          "named": true
+        },
+        {
+          "type": "preprocessor_call",
+          "named": true
+        },
+        {
+          "type": "preprocessor_define",
+          "named": true
+        },
+        {
+          "type": "preprocessor_delete",
+          "named": true
+        },
+        {
+          "type": "preprocessor_if_statement",
+          "named": true
+        },
+        {
+          "type": "preprocessor_include",
+          "named": true
+        },
+        {
+          "type": "preprocessor_output",
+          "named": true
+        },
+        {
+          "type": "preprocessor_variable_declaration",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "variable_assignment",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unary_expression",
+    "named": true,
+    "fields": {
+      "argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "parenthesised_expression",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "+",
+            "named": false
+          },
+          {
+            "type": "-",
+            "named": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "unrefined_parameter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "variable_assignment",
+    "named": true,
+    "fields": {
+      "keyword": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "existing_prm",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "!",
+            "named": false
+          },
+          {
+            "type": "@",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "compound_assignment",
+            "named": true
+          },
+          {
+            "type": "simple_assignment",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "variable_declaration",
+    "named": true,
+    "fields": {
+      "keyword": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "local",
+            "named": false
+          },
+          {
+            "type": "prm",
+            "named": false
+          }
+        ]
+      },
+      "name": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "!",
+            "named": false
+          },
+          {
+            "type": "@",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "simple_assignment",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "!",
+    "named": false
+  },
+  {
+    "type": "#_eqn",
+    "named": false
+  },
+  {
+    "type": "#define",
+    "named": false
+  },
+  {
+    "type": "#delete_macros",
+    "named": false
+  },
+  {
+    "type": "#else",
+    "named": false
+  },
+  {
+    "type": "#elseif",
+    "named": false
+  },
+  {
+    "type": "#endif",
+    "named": false
+  },
+  {
+    "type": "#if",
+    "named": false
+  },
+  {
+    "type": "#ifdef",
+    "named": false
+  },
+  {
+    "type": "#ifndef",
+    "named": false
+  },
+  {
+    "type": "#include",
+    "named": false
+  },
+  {
+    "type": "#list",
+    "named": false
+  },
+  {
+    "type": "#m_argu",
+    "named": false
+  },
+  {
+    "type": "#m_code",
+    "named": false
+  },
+  {
+    "type": "#m_code_refine",
+    "named": false
+  },
+  {
+    "type": "#m_else",
+    "named": false
+  },
+  {
+    "type": "#m_elseif",
+    "named": false
+  },
+  {
+    "type": "#m_endif",
+    "named": false
+  },
+  {
+    "type": "#m_first_word",
+    "named": false
+  },
+  {
+    "type": "#m_if",
+    "named": false
+  },
+  {
+    "type": "#m_ifarg",
+    "named": false
+  },
+  {
+    "type": "#m_one_word",
+    "named": false
+  },
+  {
+    "type": "#m_out",
+    "named": false
+  },
+  {
+    "type": "#m_unique",
+    "named": false
+  },
+  {
+    "type": "#m_unique_not_refine",
+    "named": false
+  },
+  {
+    "type": "#out",
+    "named": false
+  },
+  {
+    "type": "#prm",
+    "named": false
+  },
+  {
+    "type": "#seed",
+    "named": false
+  },
+  {
+    "type": "#undef",
+    "named": false
+  },
+  {
+    "type": "%",
+    "named": false
+  },
+  {
+    "type": "&",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": "*",
+    "named": false
+  },
+  {
+    "type": "*/",
+    "named": false
+  },
+  {
+    "type": "*=",
+    "named": false
+  },
+  {
+    "type": "+",
+    "named": false
+  },
+  {
+    "type": "+=",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": "-",
+    "named": false
+  },
+  {
+    "type": "-=",
+    "named": false
+  },
+  {
+    "type": "/",
+    "named": false
+  },
+  {
+    "type": "/*",
+    "named": false
+  },
+  {
+    "type": "/=",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": ";",
+    "named": false
+  },
+  {
+    "type": "<",
+    "named": false
+  },
+  {
+    "type": "<=",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": "==",
+    "named": false
+  },
+  {
+    "type": ">",
+    "named": false
+  },
+  {
+    "type": ">=",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "A_matrix",
+    "named": false
+  },
+  {
+    "type": "A_matrix_normalized",
+    "named": false
+  },
+  {
+    "type": "A_matrix_prm_filter",
+    "named": false
+  },
+  {
+    "type": "C_matrix",
+    "named": false
+  },
+  {
+    "type": "C_matrix_normalized",
+    "named": false
+  },
+  {
+    "type": "Flack",
+    "named": false
+  },
+  {
+    "type": "I",
+    "named": false
+  },
+  {
+    "type": "I_parameter_names_have_hkl",
+    "named": false
+  },
+  {
+    "type": "Lam",
+    "named": false
+  },
+  {
+    "type": "Rp",
+    "named": false
+  },
+  {
+    "type": "Rs",
+    "named": false
+  },
+  {
+    "type": "WPPM_L_max",
+    "named": false
+  },
+  {
+    "type": "WPPM_correct_Is",
+    "named": false
+  },
+  {
+    "type": "WPPM_ft_conv",
+    "named": false
+  },
+  {
+    "type": "WPPM_th2_range",
+    "named": false
+  },
+  {
+    "type": "^",
+    "named": false
+  },
+  {
+    "type": "^=",
+    "named": false
+  },
+  {
+    "type": "a",
+    "named": false
+  },
+  {
+    "type": "a_add",
+    "named": false
+  },
+  {
+    "type": "aberration_range_change_allowed",
+    "named": false
+  },
+  {
+    "type": "accumulate_phases_and_save_to_file",
+    "named": false
+  },
+  {
+    "type": "accumulate_phases_when",
+    "named": false
+  },
+  {
+    "type": "activate",
+    "named": false
+  },
+  {
+    "type": "add_pop_1st_2nd_peak",
+    "named": false
+  },
+  {
+    "type": "add_to_cloud_N",
+    "named": false
+  },
+  {
+    "type": "add_to_cloud_when",
+    "named": false
+  },
+  {
+    "type": "add_to_phases_of_weak_reflections",
+    "named": false
+  },
+  {
+    "type": "adps",
+    "named": false
+  },
+  {
+    "type": "ai_anti_bump",
+    "named": false
+  },
+  {
+    "type": "ai_closest_N",
+    "named": false
+  },
+  {
+    "type": "ai_exclude_eq_0",
+    "named": false
+  },
+  {
+    "type": "ai_flatten_with_tollerance_of",
+    "named": false
+  },
+  {
+    "type": "ai_no_self_interation",
+    "named": false
+  },
+  {
+    "type": "ai_only_eq_0",
+    "named": false
+  },
+  {
+    "type": "ai_radius",
+    "named": false
+  },
+  {
+    "type": "ai_sites_1",
+    "named": false
+  },
+  {
+    "type": "ai_sites_2",
+    "named": false
+  },
+  {
+    "type": "al",
+    "named": false
+  },
+  {
+    "type": "amorphous_area",
+    "named": false
+  },
+  {
+    "type": "amorphous_phase",
+    "named": false
+  },
+  {
+    "type": "append_bond_lengths",
+    "named": false
+  },
+  {
+    "type": "append_cartesian",
+    "named": false
+  },
+  {
+    "type": "append_fractional",
+    "named": false
+  },
+  {
+    "type": "apply_exp_scale",
+    "named": false
+  },
+  {
+    "type": "approximate_A",
+    "named": false
+  },
+  {
+    "type": "atom_out",
+    "named": false
+  },
+  {
+    "type": "atomic_interaction",
+    "named": false
+  },
+  {
+    "type": "auto_scale",
+    "named": false
+  },
+  {
+    "type": "auto_sparse_CG",
+    "named": false
+  },
+  {
+    "type": "axial_conv",
+    "named": false
+  },
+  {
+    "type": "axial_del",
+    "named": false
+  },
+  {
+    "type": "axial_n_beta",
+    "named": false
+  },
+  {
+    "type": "b",
+    "named": false
+  },
+  {
+    "type": "b_add",
+    "named": false
+  },
+  {
+    "type": "be",
+    "named": false
+  },
+  {
+    "type": "beq",
+    "named": false
+  },
+  {
+    "type": "bkg",
+    "named": false
+  },
+  {
+    "type": "bootstrap_errors",
+    "named": false
+  },
+  {
+    "type": "box_interaction",
+    "named": false
+  },
+  {
+    "type": "break_cycle_if_true",
+    "named": false
+  },
+  {
+    "type": "brindley_spherical_r_cm",
+    "named": false
+  },
+  {
+    "type": "bring_2nd_peak_to_top",
+    "named": false
+  },
+  {
+    "type": "broaden_peaks",
+    "named": false
+  },
+  {
+    "type": "c",
+    "named": false
+  },
+  {
+    "type": "calculate_Lam",
+    "named": false
+  },
+  {
+    "type": "capillary_diameter_mm",
+    "named": false
+  },
+  {
+    "type": "capillary_divergent_beam",
+    "named": false
+  },
+  {
+    "type": "capillary_parallel_beam",
+    "named": false
+  },
+  {
+    "type": "capillary_u_cm_inv",
+    "named": false
+  },
+  {
+    "type": "cell_mass",
+    "named": false
+  },
+  {
+    "type": "cell_volume",
+    "named": false
+  },
+  {
+    "type": "cf_hkl_file",
+    "named": false
+  },
+  {
+    "type": "cf_in_A_matrix",
+    "named": false
+  },
+  {
+    "type": "charge_flipping",
+    "named": false
+  },
+  {
+    "type": "chi2",
+    "named": false
+  },
+  {
+    "type": "chi2_convergence_criteria",
+    "named": false
+  },
+  {
+    "type": "chk_for_best",
+    "named": false
+  },
+  {
+    "type": "choose_from",
+    "named": false
+  },
+  {
+    "type": "choose_randomly",
+    "named": false
+  },
+  {
+    "type": "choose_to",
+    "named": false
+  },
+  {
+    "type": "circles_conv",
+    "named": false
+  },
+  {
+    "type": "cloud",
+    "named": false
+  },
+  {
+    "type": "cloud_I",
+    "named": false
+  },
+  {
+    "type": "cloud_N_to_extract",
+    "named": false
+  },
+  {
+    "type": "cloud_atomic_separation",
+    "named": false
+  },
+  {
+    "type": "cloud_extract_and_save_xyzs",
+    "named": false
+  },
+  {
+    "type": "cloud_fit",
+    "named": false
+  },
+  {
+    "type": "cloud_formation_omit_rwps",
+    "named": false
+  },
+  {
+    "type": "cloud_gauss_fwhm",
+    "named": false
+  },
+  {
+    "type": "cloud_load",
+    "named": false
+  },
+  {
+    "type": "cloud_load_fixed_starting",
+    "named": false
+  },
+  {
+    "type": "cloud_load_xyzs",
+    "named": false
+  },
+  {
+    "type": "cloud_load_xyzs_omit_rwps",
+    "named": false
+  },
+  {
+    "type": "cloud_match_gauss_fwhm",
+    "named": false
+  },
+  {
+    "type": "cloud_min_intensity",
+    "named": false
+  },
+  {
+    "type": "cloud_number_to_extract",
+    "named": false
+  },
+  {
+    "type": "cloud_population",
+    "named": false
+  },
+  {
+    "type": "cloud_pre_randimize_add_to",
+    "named": false
+  },
+  {
+    "type": "cloud_save",
+    "named": false
+  },
+  {
+    "type": "cloud_save_match_xy",
+    "named": false
+  },
+  {
+    "type": "cloud_save_processed_xyzs",
+    "named": false
+  },
+  {
+    "type": "cloud_save_xyzs",
+    "named": false
+  },
+  {
+    "type": "cloud_stay_within",
+    "named": false
+  },
+  {
+    "type": "cloud_try_accept",
+    "named": false
+  },
+  {
+    "type": "conserve_memory",
+    "named": false
+  },
+  {
+    "type": "consider_lattice_parameters",
+    "named": false
+  },
+  {
+    "type": "continue_after_convergence",
+    "named": false
+  },
+  {
+    "type": "convolute_X_recal",
+    "named": false
+  },
+  {
+    "type": "convolution_step",
+    "named": false
+  },
+  {
+    "type": "correct_for_atomic_scattering_factors",
+    "named": false
+  },
+  {
+    "type": "correct_for_temperature_effects",
+    "named": false
+  },
+  {
+    "type": "corrected_weight_percent",
+    "named": false
+  },
+  {
+    "type": "crystalline_area",
+    "named": false
+  },
+  {
+    "type": "current_peak_max_x",
+    "named": false
+  },
+  {
+    "type": "current_peak_min_x",
+    "named": false
+  },
+  {
+    "type": "d",
+    "named": false
+  },
+  {
+    "type": "d_Is",
+    "named": false
+  },
+  {
+    "type": "def",
+    "named": false
+  },
+  {
+    "type": "default_I_attributes",
+    "named": false
+  },
+  {
+    "type": "degree_of_crystallinity",
+    "named": false
+  },
+  {
+    "type": "del",
+    "named": false
+  },
+  {
+    "type": "del_approx",
+    "named": false
+  },
+  {
+    "type": "delete_observed_reflections",
+    "named": false
+  },
+  {
+    "type": "determine_values_from_samples",
+    "named": false
+  },
+  {
+    "type": "displace",
+    "named": false
+  },
+  {
+    "type": "do_errors",
+    "named": false
+  },
+  {
+    "type": "do_errors_include_penalties",
+    "named": false
+  },
+  {
+    "type": "do_errors_include_restraints",
+    "named": false
+  },
+  {
+    "type": "dont_merge_Friedel_pairs",
+    "named": false
+  },
+  {
+    "type": "dont_merge_equivalent_reflections",
+    "named": false
+  },
+  {
+    "type": "dummy",
+    "named": false
+  },
+  {
+    "type": "dummy_str",
+    "named": false
+  },
+  {
+    "type": "element_weight_percent",
+    "named": false
+  },
+  {
+    "type": "element_weight_percent_known",
+    "named": false
+  },
+  {
+    "type": "elemental_composition",
+    "named": false
+  },
+  {
+    "type": "exclude",
+    "named": false
+  },
+  {
+    "type": "existing_prm",
+    "named": false
+  },
+  {
+    "type": "exp_conv_const",
+    "named": false
+  },
+  {
+    "type": "exp_limit",
+    "named": false
+  },
+  {
+    "type": "extend_calculated_sphere_to",
+    "named": false
+  },
+  {
+    "type": "extra_X",
+    "named": false
+  },
+  {
+    "type": "extra_X_left",
+    "named": false
+  },
+  {
+    "type": "extra_X_right",
+    "named": false
+  },
+  {
+    "type": "f0",
+    "named": false
+  },
+  {
+    "type": "f0_f1_f11_atom",
+    "named": false
+  },
+  {
+    "type": "f1",
+    "named": false
+  },
+  {
+    "type": "f11",
+    "named": false
+  },
+  {
+    "type": "f_atom_quantity",
+    "named": false
+  },
+  {
+    "type": "f_atom_type",
+    "named": false
+  },
+  {
+    "type": "filament_length",
+    "named": false
+  },
+  {
+    "type": "file_out",
+    "named": false
+  },
+  {
+    "type": "find_origin",
+    "named": false
+  },
+  {
+    "type": "finish_X",
+    "named": false
+  },
+  {
+    "type": "fit_obj",
+    "named": false
+  },
+  {
+    "type": "fit_obj_phase",
+    "named": false
+  },
+  {
+    "type": "flat_crystal_pre_monochromator_axial_const",
+    "named": false
+  },
+  {
+    "type": "flip_equation",
+    "named": false
+  },
+  {
+    "type": "flip_neutron",
+    "named": false
+  },
+  {
+    "type": "flip_regime_2",
+    "named": false
+  },
+  {
+    "type": "flip_regime_3",
+    "named": false
+  },
+  {
+    "type": "fn",
+    "named": false
+  },
+  {
+    "type": "fo_transform_X",
+    "named": false
+  },
+  {
+    "type": "fourier_map",
+    "named": false
+  },
+  {
+    "type": "fourier_map_formula",
+    "named": false
+  },
+  {
+    "type": "fraction_density_to_flip",
+    "named": false
+  },
+  {
+    "type": "fraction_of_yobs_to_resample",
+    "named": false
+  },
+  {
+    "type": "fraction_reflections_weak",
+    "named": false
+  },
+  {
+    "type": "ft_L_max",
+    "named": false
+  },
+  {
+    "type": "ft_conv",
+    "named": false
+  },
+  {
+    "type": "ft_convolution",
+    "named": false
+  },
+  {
+    "type": "ft_min",
+    "named": false
+  },
+  {
+    "type": "ft_x_axis_range",
+    "named": false
+  },
+  {
+    "type": "fullprof_format",
+    "named": false
+  },
+  {
+    "type": "ga",
+    "named": false
+  },
+  {
+    "type": "gauss_fwhm",
+    "named": false
+  },
+  {
+    "type": "generate_name_append",
+    "named": false
+  },
+  {
+    "type": "generate_stack_sequences",
+    "named": false
+  },
+  {
+    "type": "generate_these",
+    "named": false
+  },
+  {
+    "type": "gof",
+    "named": false
+  },
+  {
+    "type": "grs_interaction",
+    "named": false
+  },
+  {
+    "type": "gsas_format",
+    "named": false
+  },
+  {
+    "type": "gui_add_bkg",
+    "named": false
+  },
+  {
+    "type": "h1",
+    "named": false
+  },
+  {
+    "type": "h2",
+    "named": false
+  },
+  {
+    "type": "half_hat",
+    "named": false
+  },
+  {
+    "type": "hat",
+    "named": false
+  },
+  {
+    "type": "hat_height",
+    "named": false
+  },
+  {
+    "type": "height",
+    "named": false
+  },
+  {
+    "type": "histogram_match_scale_fwhm",
+    "named": false
+  },
+  {
+    "type": "hkl_Is",
+    "named": false
+  },
+  {
+    "type": "hkl_Re_Im",
+    "named": false
+  },
+  {
+    "type": "hkl_m_d_th2",
+    "named": false
+  },
+  {
+    "type": "hklis",
+    "named": false
+  },
+  {
+    "type": "hm_covalent_fwhm",
+    "named": false
+  },
+  {
+    "type": "hm_size_limit_in_fwhm",
+    "named": false
+  },
+  {
+    "type": "i_on_error_ratio_tolerance",
+    "named": false
+  },
+  {
+    "type": "identifier",
+    "named": true
+  },
+  {
+    "type": "ignore_differences_in_Friedel_pairs",
+    "named": false
+  },
+  {
+    "type": "in_FC",
+    "named": false
+  },
+  {
+    "type": "in_cartesian",
+    "named": false
+  },
+  {
+    "type": "in_str_format",
+    "named": false
+  },
+  {
+    "type": "index_I",
+    "named": false
+  },
+  {
+    "type": "index_d",
+    "named": false
+  },
+  {
+    "type": "index_exclude_max_on_min_lp_less_than",
+    "named": false
+  },
+  {
+    "type": "index_lam",
+    "named": false
+  },
+  {
+    "type": "index_max_Nc_on_No",
+    "named": false
+  },
+  {
+    "type": "index_max_lp",
+    "named": false
+  },
+  {
+    "type": "index_max_number_of_solutions",
+    "named": false
+  },
+  {
+    "type": "index_max_th2_error",
+    "named": false
+  },
+  {
+    "type": "index_max_zero_error",
+    "named": false
+  },
+  {
+    "type": "index_min_lp",
+    "named": false
+  },
+  {
+    "type": "index_th2",
+    "named": false
+  },
+  {
+    "type": "index_th2_resolution",
+    "named": false
+  },
+  {
+    "type": "index_x0",
+    "named": false
+  },
+  {
+    "type": "index_zero_error",
+    "named": false
+  },
+  {
+    "type": "insert",
+    "named": false
+  },
+  {
+    "type": "integer_literal",
+    "named": true
+  },
+  {
+    "type": "inter",
+    "named": false
+  },
+  {
+    "type": "iters",
+    "named": false
+  },
+  {
+    "type": "la",
+    "named": false
+  },
+  {
+    "type": "lam",
+    "named": false
+  },
+  {
+    "type": "layer",
+    "named": false
+  },
+  {
+    "type": "layers_tol",
+    "named": false
+  },
+  {
+    "type": "lebail",
+    "named": false
+  },
+  {
+    "type": "lg",
+    "named": false
+  },
+  {
+    "type": "lh",
+    "named": false
+  },
+  {
+    "type": "line_comment",
+    "named": true
+  },
+  {
+    "type": "line_min",
+    "named": false
+  },
+  {
+    "type": "lo",
+    "named": false
+  },
+  {
+    "type": "load",
+    "named": false
+  },
+  {
+    "type": "local",
+    "named": false
+  },
+  {
+    "type": "lor_fwhm",
+    "named": false
+  },
+  {
+    "type": "lp_search",
+    "named": false
+  },
+  {
+    "type": "lpsd_beam_spill_correct_intensity",
+    "named": false
+  },
+  {
+    "type": "lpsd_equitorial_divergence_degrees",
+    "named": false
+  },
+  {
+    "type": "lpsd_equitorial_sample_length_mm",
+    "named": false
+  },
+  {
+    "type": "lpsd_th2_angular_range_degrees",
+    "named": false
+  },
+  {
+    "type": "m1",
+    "named": false
+  },
+  {
+    "type": "m2",
+    "named": false
+  },
+  {
+    "type": "macro",
+    "named": false
+  },
+  {
+    "type": "mag_atom_out",
+    "named": false
+  },
+  {
+    "type": "mag_only",
+    "named": false
+  },
+  {
+    "type": "mag_only_for_mag_sites",
+    "named": false
+  },
+  {
+    "type": "mag_space_group",
+    "named": false
+  },
+  {
+    "type": "marquardt_constant",
+    "named": false
+  },
+  {
+    "type": "match_transition_matrix_stats",
+    "named": false
+  },
+  {
+    "type": "max",
+    "named": false
+  },
+  {
+    "type": "max_X",
+    "named": false
+  },
+  {
+    "type": "max_r",
+    "named": false
+  },
+  {
+    "type": "mg",
+    "named": false
+  },
+  {
+    "type": "min",
+    "named": false
+  },
+  {
+    "type": "min_X",
+    "named": false
+  },
+  {
+    "type": "min_d",
+    "named": false
+  },
+  {
+    "type": "min_grid_spacing",
+    "named": false
+  },
+  {
+    "type": "min_r",
+    "named": false
+  },
+  {
+    "type": "mixture_MAC",
+    "named": false
+  },
+  {
+    "type": "mixture_density_g_on_cm3",
+    "named": false
+  },
+  {
+    "type": "mlx",
+    "named": false
+  },
+  {
+    "type": "mly",
+    "named": false
+  },
+  {
+    "type": "mlz",
+    "named": false
+  },
+  {
+    "type": "modify_initial_phases",
+    "named": false
+  },
+  {
+    "type": "modify_peak",
+    "named": false
+  },
+  {
+    "type": "modify_peak_apply_before_convolutions",
+    "named": false
+  },
+  {
+    "type": "modify_peak_eqn",
+    "named": false
+  },
+  {
+    "type": "more_accurate_Voigt",
+    "named": false
+  },
+  {
+    "type": "move_to",
+    "named": false
+  },
+  {
+    "type": "move_to_the_next_temperature_regardless_of_the_change_in_rwp",
+    "named": false
+  },
+  {
+    "type": "n",
+    "named": false
+  },
+  {
+    "type": "n1",
+    "named": false
+  },
+  {
+    "type": "n2",
+    "named": false
+  },
+  {
+    "type": "n3",
+    "named": false
+  },
+  {
+    "type": "n_avg",
+    "named": false
+  },
+  {
+    "type": "ndx_allp",
+    "named": false
+  },
+  {
+    "type": "ndx_alp",
+    "named": false
+  },
+  {
+    "type": "ndx_belp",
+    "named": false
+  },
+  {
+    "type": "ndx_blp",
+    "named": false
+  },
+  {
+    "type": "ndx_clp",
+    "named": false
+  },
+  {
+    "type": "ndx_galp",
+    "named": false
+  },
+  {
+    "type": "ndx_gof",
+    "named": false
+  },
+  {
+    "type": "ndx_sg",
+    "named": false
+  },
+  {
+    "type": "ndx_uni",
+    "named": false
+  },
+  {
+    "type": "ndx_vol",
+    "named": false
+  },
+  {
+    "type": "ndx_ze",
+    "named": false
+  },
+  {
+    "type": "neutron_data",
+    "named": false
+  },
+  {
+    "type": "no_LIMIT_warnings",
+    "named": false
+  },
+  {
+    "type": "no_f11",
+    "named": false
+  },
+  {
+    "type": "no_inline",
+    "named": false
+  },
+  {
+    "type": "no_normal_equations",
+    "named": false
+  },
+  {
+    "type": "no_th_dependence",
+    "named": false
+  },
+  {
+    "type": "normalize_FCs",
+    "named": false
+  },
+  {
+    "type": "normals_plot",
+    "named": false
+  },
+  {
+    "type": "normals_plot_min_d",
+    "named": false
+  },
+  {
+    "type": "num_hats",
+    "named": false
+  },
+  {
+    "type": "num_highest_I_values_to_keep",
+    "named": false
+  },
+  {
+    "type": "num_patterns_at_a_time",
+    "named": false
+  },
+  {
+    "type": "num_posns",
+    "named": false
+  },
+  {
+    "type": "num_runs",
+    "named": false
+  },
+  {
+    "type": "num_unique_vx_vy",
+    "named": false
+  },
+  {
+    "type": "number_of_sequences",
+    "named": false
+  },
+  {
+    "type": "number_of_stacks_per_sequence",
+    "named": false
+  },
+  {
+    "type": "numerical_area",
+    "named": false
+  },
+  {
+    "type": "numerical_lor_gauss_conv",
+    "named": false
+  },
+  {
+    "type": "numerical_lor_ymin_on_ymax",
+    "named": false
+  },
+  {
+    "type": "occ",
+    "named": false
+  },
+  {
+    "type": "occ_merge",
+    "named": false
+  },
+  {
+    "type": "occ_merge_radius",
+    "named": false
+  },
+  {
+    "type": "omit",
+    "named": false
+  },
+  {
+    "type": "omit_hkls",
+    "named": false
+  },
+  {
+    "type": "on_best_goto",
+    "named": false
+  },
+  {
+    "type": "on_best_rewind",
+    "named": false
+  },
+  {
+    "type": "one_on_x_conv",
+    "named": false
+  },
+  {
+    "type": "only_lps",
+    "named": false
+  },
+  {
+    "type": "only_penalties",
+    "named": false
+  },
+  {
+    "type": "operate_on_points",
+    "named": false
+  },
+  {
+    "type": "out",
+    "named": false
+  },
+  {
+    "type": "out_A_matrix",
+    "named": false
+  },
+  {
+    "type": "out_chi2",
+    "named": false
+  },
+  {
+    "type": "out_dependences",
+    "named": false
+  },
+  {
+    "type": "out_dependents_for",
+    "named": false
+  },
+  {
+    "type": "out_eqn",
+    "named": false
+  },
+  {
+    "type": "out_file",
+    "named": false
+  },
+  {
+    "type": "out_fmt",
+    "named": false
+  },
+  {
+    "type": "out_fmt_err",
+    "named": false
+  },
+  {
+    "type": "out_prm_vals_dependents_filter",
+    "named": false
+  },
+  {
+    "type": "out_prm_vals_filter",
+    "named": false
+  },
+  {
+    "type": "out_prm_vals_on_convergence",
+    "named": false
+  },
+  {
+    "type": "out_prm_vals_per_iteration",
+    "named": false
+  },
+  {
+    "type": "out_record",
+    "named": false
+  },
+  {
+    "type": "out_refinement_stats",
+    "named": false
+  },
+  {
+    "type": "out_rwp",
+    "named": false
+  },
+  {
+    "type": "pdf_convolute",
+    "named": false
+  },
+  {
+    "type": "pdf_data",
+    "named": false
+  },
+  {
+    "type": "pdf_for_pairs",
+    "named": false
+  },
+  {
+    "type": "pdf_gauss_fwhm",
+    "named": false
+  },
+  {
+    "type": "pdf_info",
+    "named": false
+  },
+  {
+    "type": "pdf_only_eq_0",
+    "named": false
+  },
+  {
+    "type": "pdf_scale_simple",
+    "named": false
+  },
+  {
+    "type": "pdf_ymin_on_ymax",
+    "named": false
+  },
+  {
+    "type": "pdf_zero",
+    "named": false
+  },
+  {
+    "type": "peak_buffer_based_on",
+    "named": false
+  },
+  {
+    "type": "peak_buffer_based_on_tol",
+    "named": false
+  },
+  {
+    "type": "peak_buffer_step",
+    "named": false
+  },
+  {
+    "type": "peak_type",
+    "named": false
+  },
+  {
+    "type": "pen_weight",
+    "named": false
+  },
+  {
+    "type": "penalties_weighting_K1",
+    "named": false
+  },
+  {
+    "type": "penalty",
+    "named": false
+  },
+  {
+    "type": "percent_zeros_before_sparse_A",
+    "named": false
+  },
+  {
+    "type": "phase_MAC",
+    "named": false
+  },
+  {
+    "type": "phase_name",
+    "named": false
+  },
+  {
+    "type": "phase_out",
+    "named": false
+  },
+  {
+    "type": "phase_penalties",
+    "named": false
+  },
+  {
+    "type": "pick_atoms",
+    "named": false
+  },
+  {
+    "type": "pick_atoms_when",
+    "named": false
+  },
+  {
+    "type": "pk_xo",
+    "named": false
+  },
+  {
+    "type": "point_for_site",
+    "named": false
+  },
+  {
+    "type": "pr_str",
+    "named": false
+  },
+  {
+    "type": "primary_soller_angle",
+    "named": false
+  },
+  {
+    "type": "prm",
+    "named": false
+  },
+  {
+    "type": "prm_with_error",
+    "named": false
+  },
+  {
+    "type": "process_times",
+    "named": false
+  },
+  {
+    "type": "push_peak",
+    "named": false
+  },
+  {
+    "type": "pv_fwhm",
+    "named": false
+  },
+  {
+    "type": "pv_lor",
+    "named": false
+  },
+  {
+    "type": "qa",
+    "named": false
+  },
+  {
+    "type": "qb",
+    "named": false
+  },
+  {
+    "type": "qc",
+    "named": false
+  },
+  {
+    "type": "quick_refine",
+    "named": false
+  },
+  {
+    "type": "quick_refine_remove",
+    "named": false
+  },
+  {
+    "type": "qx",
+    "named": false
+  },
+  {
+    "type": "qy",
+    "named": false
+  },
+  {
+    "type": "qz",
+    "named": false
+  },
+  {
+    "type": "r_bragg",
+    "named": false
+  },
+  {
+    "type": "r_exp",
+    "named": false
+  },
+  {
+    "type": "r_exp_dash",
+    "named": false
+  },
+  {
+    "type": "r_p",
+    "named": false
+  },
+  {
+    "type": "r_p_dash",
+    "named": false
+  },
+  {
+    "type": "r_wp",
+    "named": false
+  },
+  {
+    "type": "r_wp_dash",
+    "named": false
+  },
+  {
+    "type": "r_wp_normal",
+    "named": false
+  },
+  {
+    "type": "rand_xyz",
+    "named": false
+  },
+  {
+    "type": "randomize_initial_phases_by",
+    "named": false
+  },
+  {
+    "type": "randomize_on_errors",
+    "named": false
+  },
+  {
+    "type": "randomize_phases_on_new_cycle_by",
+    "named": false
+  },
+  {
+    "type": "range",
+    "named": false
+  },
+  {
+    "type": "rebin_min_merge",
+    "named": false
+  },
+  {
+    "type": "rebin_tollerance_in_Y",
+    "named": false
+  },
+  {
+    "type": "rebin_with_dx_of",
+    "named": false
+  },
+  {
+    "type": "recal_weighting_on_iter",
+    "named": false
+  },
+  {
+    "type": "receiving_slit_length",
+    "named": false
+  },
+  {
+    "type": "redo_hkls",
+    "named": false
+  },
+  {
+    "type": "remove_phase",
+    "named": false
+  },
+  {
+    "type": "report_on",
+    "named": false
+  },
+  {
+    "type": "report_on_str",
+    "named": false
+  },
+  {
+    "type": "resample_from_current_ycalc",
+    "named": false
+  },
+  {
+    "type": "restraint",
+    "named": false
+  },
+  {
+    "type": "return",
+    "named": false
+  },
+  {
+    "type": "rigid",
+    "named": false
+  },
+  {
+    "type": "rotate",
+    "named": false
+  },
+  {
+    "type": "sample_length",
+    "named": false
+  },
+  {
+    "type": "save_best_chi2",
+    "named": false
+  },
+  {
+    "type": "save_sequences",
+    "named": false
+  },
+  {
+    "type": "save_sequences_as_strs",
+    "named": false
+  },
+  {
+    "type": "save_values_as_best_after_randomization",
+    "named": false
+  },
+  {
+    "type": "scale",
+    "named": false
+  },
+  {
+    "type": "scale_Aij",
+    "named": false
+  },
+  {
+    "type": "scale_E",
+    "named": false
+  },
+  {
+    "type": "scale_F",
+    "named": false
+  },
+  {
+    "type": "scale_F000",
+    "named": false
+  },
+  {
+    "type": "scale_density_below_threshold",
+    "named": false
+  },
+  {
+    "type": "scale_phase_X",
+    "named": false
+  },
+  {
+    "type": "scale_phases",
+    "named": false
+  },
+  {
+    "type": "scale_pks",
+    "named": false
+  },
+  {
+    "type": "scale_top_peak",
+    "named": false
+  },
+  {
+    "type": "scale_weak_reflections",
+    "named": false
+  },
+  {
+    "type": "secondary_soller_angle",
+    "named": false
+  },
+  {
+    "type": "seed",
+    "named": false
+  },
+  {
+    "type": "set_initial_phases_to",
+    "named": false
+  },
+  {
+    "type": "sh_Cij_prm",
+    "named": false
+  },
+  {
+    "type": "sh_alpha",
+    "named": false
+  },
+  {
+    "type": "sh_order",
+    "named": false
+  },
+  {
+    "type": "site",
+    "named": false
+  },
+  {
+    "type": "site_to_restrain",
+    "named": false
+  },
+  {
+    "type": "sites_angle",
+    "named": false
+  },
+  {
+    "type": "sites_avg_rand_xyz",
+    "named": false
+  },
+  {
+    "type": "sites_distance",
+    "named": false
+  },
+  {
+    "type": "sites_flatten",
+    "named": false
+  },
+  {
+    "type": "sites_geometry",
+    "named": false
+  },
+  {
+    "type": "sites_rand_on_avg",
+    "named": false
+  },
+  {
+    "type": "sites_rand_on_avg_distance_to_randomize",
+    "named": false
+  },
+  {
+    "type": "sites_rand_on_avg_min_distance",
+    "named": false
+  },
+  {
+    "type": "siv_s1_s2",
+    "named": false
+  },
+  {
+    "type": "smooth",
+    "named": false
+  },
+  {
+    "type": "space_group",
+    "named": false
+  },
+  {
+    "type": "sparse_A",
+    "named": false
+  },
+  {
+    "type": "spherical_harmonics_hkl",
+    "named": false
+  },
+  {
+    "type": "spiked_phase_measured_weight_percent",
+    "named": false
+  },
+  {
+    "type": "spv_h1",
+    "named": false
+  },
+  {
+    "type": "spv_h2",
+    "named": false
+  },
+  {
+    "type": "spv_l1",
+    "named": false
+  },
+  {
+    "type": "spv_l2",
+    "named": false
+  },
+  {
+    "type": "stack",
+    "named": false
+  },
+  {
+    "type": "stacked_hats_conv",
+    "named": false
+  },
+  {
+    "type": "start_X",
+    "named": false
+  },
+  {
+    "type": "start_values_from_site",
+    "named": false
+  },
+  {
+    "type": "stop_when",
+    "named": false
+  },
+  {
+    "type": "str",
+    "named": false
+  },
+  {
+    "type": "str_hkl_angle",
+    "named": false
+  },
+  {
+    "type": "str_hkl_smallest_angle",
+    "named": false
+  },
+  {
+    "type": "str_mass",
+    "named": false
+  },
+  {
+    "type": "string_literal",
+    "named": true
+  },
+  {
+    "type": "strs",
+    "named": false
+  },
+  {
+    "type": "sx",
+    "named": false
+  },
+  {
+    "type": "sy",
+    "named": false
+  },
+  {
+    "type": "symmetry_obey_0_to_1",
+    "named": false
+  },
+  {
+    "type": "system_after_save_OUT",
+    "named": false
+  },
+  {
+    "type": "system_before_save_OUT",
+    "named": false
+  },
+  {
+    "type": "sz",
+    "named": false
+  },
+  {
+    "type": "ta",
+    "named": false
+  },
+  {
+    "type": "tag",
+    "named": false
+  },
+  {
+    "type": "tag_2",
+    "named": false
+  },
+  {
+    "type": "tangent_max_triplets_per_h",
+    "named": false
+  },
+  {
+    "type": "tangent_min_triplets_per_h",
+    "named": false
+  },
+  {
+    "type": "tangent_num_h_keep",
+    "named": false
+  },
+  {
+    "type": "tangent_num_h_read",
+    "named": false
+  },
+  {
+    "type": "tangent_num_k_read",
+    "named": false
+  },
+  {
+    "type": "tangent_scale_difference_by",
+    "named": false
+  },
+  {
+    "type": "tangent_tiny",
+    "named": false
+  },
+  {
+    "type": "tb",
+    "named": false
+  },
+  {
+    "type": "tc",
+    "named": false
+  },
+  {
+    "type": "temperature",
+    "named": false
+  },
+  {
+    "type": "test_a",
+    "named": false
+  },
+  {
+    "type": "test_al",
+    "named": false
+  },
+  {
+    "type": "test_b",
+    "named": false
+  },
+  {
+    "type": "test_be",
+    "named": false
+  },
+  {
+    "type": "test_c",
+    "named": false
+  },
+  {
+    "type": "test_ga",
+    "named": false
+  },
+  {
+    "type": "th2_offset",
+    "named": false
+  },
+  {
+    "type": "to",
+    "named": false
+  },
+  {
+    "type": "transition",
+    "named": false
+  },
+  {
+    "type": "translate",
+    "named": false
+  },
+  {
+    "type": "try_space_groups",
+    "named": false
+  },
+  {
+    "type": "two_theta_calibration",
+    "named": false
+  },
+  {
+    "type": "tx",
+    "named": false
+  },
+  {
+    "type": "ty",
+    "named": false
+  },
+  {
+    "type": "tz",
+    "named": false
+  },
+  {
+    "type": "u11",
+    "named": false
+  },
+  {
+    "type": "u12",
+    "named": false
+  },
+  {
+    "type": "u13",
+    "named": false
+  },
+  {
+    "type": "u22",
+    "named": false
+  },
+  {
+    "type": "u23",
+    "named": false
+  },
+  {
+    "type": "u33",
+    "named": false
+  },
+  {
+    "type": "ua",
+    "named": false
+  },
+  {
+    "type": "ub",
+    "named": false
+  },
+  {
+    "type": "uc",
+    "named": false
+  },
+  {
+    "type": "update",
+    "named": false
+  },
+  {
+    "type": "use_CG",
+    "named": false
+  },
+  {
+    "type": "use_Fc",
+    "named": false
+  },
+  {
+    "type": "use_LU",
+    "named": false
+  },
+  {
+    "type": "use_LU_for_errors",
+    "named": false
+  },
+  {
+    "type": "use_best_values",
+    "named": false
+  },
+  {
+    "type": "use_extrapolation",
+    "named": false
+  },
+  {
+    "type": "use_layer",
+    "named": false
+  },
+  {
+    "type": "use_tube_dispersion_coefficients",
+    "named": false
+  },
+  {
+    "type": "user_defined_convolution",
+    "named": false
+  },
+  {
+    "type": "user_threshold",
+    "named": false
+  },
+  {
+    "type": "user_y",
+    "named": false
+  },
+  {
+    "type": "ux",
+    "named": false
+  },
+  {
+    "type": "uy",
+    "named": false
+  },
+  {
+    "type": "uz",
+    "named": false
+  },
+  {
+    "type": "v1",
+    "named": false
+  },
+  {
+    "type": "val_on_continue",
+    "named": false
+  },
+  {
+    "type": "verbose",
+    "named": false
+  },
+  {
+    "type": "view_cloud",
+    "named": false
+  },
+  {
+    "type": "view_structure",
+    "named": false
+  },
+  {
+    "type": "volume",
+    "named": false
+  },
+  {
+    "type": "weight_percent",
+    "named": false
+  },
+  {
+    "type": "weight_percent_amorphous",
+    "named": false
+  },
+  {
+    "type": "weighted_Durbin_Watson",
+    "named": false
+  },
+  {
+    "type": "weighting",
+    "named": false
+  },
+  {
+    "type": "weighting_normal",
+    "named": false
+  },
+  {
+    "type": "whole_hat",
+    "named": false
+  },
+  {
+    "type": "x",
+    "named": false
+  },
+  {
+    "type": "x_angle_scaler",
+    "named": false
+  },
+  {
+    "type": "x_axis_to_energy_in_eV",
+    "named": false
+  },
+  {
+    "type": "x_calculation_step",
+    "named": false
+  },
+  {
+    "type": "x_scaler",
+    "named": false
+  },
+  {
+    "type": "xdd",
+    "named": false
+  },
+  {
+    "type": "xdd_out",
+    "named": false
+  },
+  {
+    "type": "xdd_scr",
+    "named": false
+  },
+  {
+    "type": "xdd_sum",
+    "named": false
+  },
+  {
+    "type": "xdds",
+    "named": false
+  },
+  {
+    "type": "xo",
+    "named": false
+  },
+  {
+    "type": "xo_Is",
+    "named": false
+  },
+  {
+    "type": "xye_format",
+    "named": false
+  },
+  {
+    "type": "y",
+    "named": false
+  },
+  {
+    "type": "yc_eqn",
+    "named": false
+  },
+  {
+    "type": "ymin_on_ymax",
+    "named": false
+  },
+  {
+    "type": "yobs_eqn",
+    "named": false
+  },
+  {
+    "type": "yobs_to_xo_posn_yobs",
+    "named": false
+  },
+  {
+    "type": "z",
+    "named": false
+  },
+  {
+    "type": "z_add",
+    "named": false
+  },
+  {
+    "type": "z_matrix",
+    "named": false
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  }
+]

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -1,0 +1,290 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(default : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -1,0 +1,266 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_


### PR DESCRIPTION
Adds pre-generated parser files to the repository by removing the `src/` directory from `.gitignore`. This will allow users to add TOPAS parsing to [Nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) without needing to install the Tree-sitter CLI.