### PR TITLE
Arrow comments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -18,6 +18,7 @@ module.exports = grammar({
     /\s|\n/,
     $.line_comment,
     $.block_comment,
+    $.arrow_comment,
   ],
 
   rules: {
@@ -30,6 +31,8 @@ module.exports = grammar({
       repeat(/./),
       '*/',
     ),
+
+    arrow_comment: $ => /->.*/,
 
     _literal: $ => choice($.string_literal, $.integer_literal, $.float_literal),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,6 +1,8 @@
 (definition) @keyword
 (line_comment) @comment
 (block_comment) @comment
+(arrow_comment) @comment.todo
+
 (string_literal) @string
 (integer_literal) @number
 (float_literal) @number

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -54,6 +54,10 @@
         }
       ]
     },
+    "arrow_comment": {
+      "type": "PATTERN",
+      "value": "->.*"
+    },
     "_literal": {
       "type": "CHOICE",
       "members": [
@@ -6959,6 +6963,10 @@
     {
       "type": "SYMBOL",
       "name": "block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "arrow_comment"
     }
   ],
   "conflicts": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4094,6 +4094,10 @@
     "named": false
   },
   {
+    "type": "arrow_comment",
+    "named": true
+  },
+  {
     "type": "atom_out",
     "named": false
   },

--- a/test/corpus/comments.inp
+++ b/test/corpus/comments.inp
@@ -28,3 +28,17 @@ activate
     (line_comment))
   (definition))
 
+==============
+Arrow comments
+==============
+
+-> Text to be replaced
+prm !dmin_value  ->enter min d-spacing reflections to use here
+
+--------------
+(source_file
+  (arrow_comment)
+  (variable_declaration
+    (identifier)
+    (arrow_comment)
+    (MISSING string_literal)))


### PR DESCRIPTION
Closes #20 (autofold blocks are to remain as regular line comments).

Adds the grammar to support arrow comments used in jEdit to highlight text that the user needs to change. E.g.,
`prm !dmin_value  ->enter min d-spacing reflections to use here`

In `highlights.scm`, arrow comments are tagged as `comments.todo`, one of the highlight groups supported by [Nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter). Users can change the colour of this group in their config file or in Nvim to distinguish arrow comments from regular comments.