### PR TITLE
Build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,26 @@ jobs:
       - name: Run parser tests
         shell: sh
         run: tree-sitter test
+
+  build:
+    name: Build WASM bindings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.1
+
+      - name: Set up tree-sitter
+        uses: tree-sitter/setup-action/cli@v1
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+
+      - name: Build WASM
+        shell: sh
+        run: tree-sitter build --wasm
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: tree-sitter-topas.wasm
+          path: ./tree-sitter-topas.wasm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish release
+
+on: 
+  push:
+    branches: main
+    tags: ["*"]
+
+jobs:
+  release:
+    uses: tree-sitter/workflows/.github/workflows/release.yml@main
+      with:
+        generate: true


### PR DESCRIPTION
Adds a step to `ci.yml` to build the Wasm bindings and upload the file as an artifact.

Also creates `publish.yml`, a workflow to produce a release for the repository using the [Tree-sitter release workflow](https://github.com/tree-sitter/workflows).