### PR TITLE
Add attestation permissions to publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,11 @@ on:
       - main
     tags: ["*"]
 
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   release:
     uses: tree-sitter/workflows/.github/workflows/release.yml@main


### PR DESCRIPTION
The [Tree-sitter release action ](https://github.com/tree-sitter/workflows/) cannot run without the permissions required to produce attestations, despite attestations being disabled by default. The following error message is currently observed:
```
The workflow is not valid. .github/workflows/publish.yml (Line: 10, Col: 3): Error calling workflow 'tree-sitter/workflows/.github/workflows/release.yml@main'. The workflow is requesting 'attestations: write, contents: write, id-token: write', but is only allowed 'attestations: none, contents: read, id-token: none'.
```
This will add the required permissions.